### PR TITLE
Refactor amplification loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 
+sudo: required
+
 jdk:
   - oraclejdk8
 

--- a/src/main/java/fr/inria/diversify/dspot/Amplification.java
+++ b/src/main/java/fr/inria/diversify/dspot/Amplification.java
@@ -123,7 +123,6 @@ public class Amplification {
             Log.debug("{} tests selected to be amplified over {} available tests", testToBeAmplified.size(), newTests.size());
 
             newTests = reduce(amplifyTests(testToBeAmplified));
-            Log.debug("{} new tests generated", newTests.size());
 
             List<CtMethod> testWithAssertions = assertGenerator.generateAsserts(classTest, newTests, AmplificationHelper.getAmpTestToParent());
             if (testWithAssertions.isEmpty()) {
@@ -131,7 +130,6 @@ public class Amplification {
             } else {
                 newTests = testWithAssertions;
             }
-            Log.debug("{} new tests with assertions generated", newTests.size());
 
             CtType classWithLogger = classWithLoggerBuilder.buildClassWithLogger(classTest, newTests);
             boolean status = writeAndCompile(classWithLogger);
@@ -139,7 +137,6 @@ public class Amplification {
                 break;
             }
 
-            Log.debug("run tests");
             JunitResult result = runTests(classWithLogger, newTests);
             if (result == null) {
                 continue;
@@ -150,6 +147,7 @@ public class Amplification {
             testSelector.update();
 
             newTests = AmplificationHelper.filterTest(newTests, result);
+            Log.debug("{} test method(s) has been successfully generated", newTests.size());
             amplifiedTests.addAll(testSelector.selectTestAmongAmplifiedTests(newTests));
             ampTests.addAll(newTests);
         }
@@ -157,10 +155,12 @@ public class Amplification {
     }
 
     private List<CtMethod> amplifyTests(Collection<CtMethod> tests) {
-        return tests.stream()
+        List<CtMethod> amplifiedTests = tests.stream()
                 .flatMap(test -> amplifyTest(test).stream())
                 .filter(test -> test != null && !test.getBody().getStatements().isEmpty())
                 .collect(Collectors.toList());
+        Log.debug("{} new tests generated", amplifiedTests.size());
+        return amplifiedTests;
     }
 
     private List<CtMethod> amplifyTest(CtMethod test) {
@@ -204,6 +204,7 @@ public class Amplification {
     }
 
     private JunitResult runTests(CtType testClass, Collection<CtMethod> tests) throws ClassNotFoundException {
+        Log.debug("run test class: {}", testClass.getQualifiedName());
         ClassLoader classLoader = new DiversifyClassLoader(applicationClassLoader, compiler.getBinaryOutputDirectory().getAbsolutePath());
         JunitRunner junitRunner = new JunitRunner(classLoader);
         Logger.reset();

--- a/src/main/java/fr/inria/diversify/dspot/Amplification.java
+++ b/src/main/java/fr/inria/diversify/dspot/Amplification.java
@@ -115,7 +115,7 @@ public class Amplification {
         for (int i = 0; i < maxIteration; i++) {
             Log.debug("iteration {}:", i);
 
-            List<CtMethod> testToBeAmplified = testSelector.selectTests(ampTests, newTests);
+            List<CtMethod> testToBeAmplified = testSelector.selectTestToBeAmplified(ampTests, newTests);
             if (testToBeAmplified.isEmpty()) {
                 Log.debug("No test could be generated from selected test");
                 continue;
@@ -150,7 +150,7 @@ public class Amplification {
             testSelector.update();
 
             newTests = AmplificationHelper.filterTest(newTests, result);
-            amplifiedTests.addAll(testSelector.selectedAmplifiedTests(newTests));
+            amplifiedTests.addAll(testSelector.selectTestAmongAmplifiedTests(newTests));
             ampTests.addAll(newTests);
         }
         return amplifiedTests;

--- a/src/main/java/fr/inria/diversify/dspot/AmplificationHelper.java
+++ b/src/main/java/fr/inria/diversify/dspot/AmplificationHelper.java
@@ -40,6 +40,11 @@ public class AmplificationHelper {
         importByClass = new HashMap<>();
     }
 
+    public static CtType addAmplifiedTestToClass(List<CtMethod> ampTest, CtType classTest) {
+        ampTest.forEach(classTest::addMethod);
+        return classTest;
+    }
+
     public static Map<CtMethod, CtMethod> getAmpTestToParent() {
         return ampTestToParent;
     }
@@ -87,7 +92,6 @@ public class AmplificationHelper {
 
     public static CtMethod cloneMethod(CtMethod method, String suffix) {
         CtMethod cloned_method = method.clone();
-        cloned_method.setParent(method.getParent());
         //rename the clone
         cloned_method.setSimpleName(method.getSimpleName()+suffix+cloneNumber);
         cloneNumber++;

--- a/src/main/java/fr/inria/diversify/dspot/DSpot.java
+++ b/src/main/java/fr/inria/diversify/dspot/DSpot.java
@@ -87,7 +87,9 @@ public class DSpot {
     }
 
     public CtType amplifyTest(String fullName) throws InterruptedException, IOException, ClassNotFoundException {
-        return amplifyTest(inputProgram.getFactory().Type().get(fullName));
+        CtType<Object> clone = inputProgram.getFactory().Type().get(fullName).clone();
+        clone.setParent(inputProgram.getFactory().Type().get(fullName).getParent());
+        return amplifyTest(clone);
     }
 
     public CtType amplifyTest(CtType test) {

--- a/src/main/java/fr/inria/diversify/dspot/TestSelector.java
+++ b/src/main/java/fr/inria/diversify/dspot/TestSelector.java
@@ -63,7 +63,7 @@ public class TestSelector {
      * Tests are selected by the path they cover
      * If a path is already covered, the old test is replaced by the new one with 0.5 of probability
      */
-    public Collection<CtMethod> selectTests(Collection<CtMethod> oldTests, Collection<CtMethod> testToBeSelected) {
+    public List<CtMethod> selectTests(Collection<CtMethod> oldTests, Collection<CtMethod> testToBeSelected) {
         Map<CtMethod, Set<String>> selectedTest = new HashMap<>();
         for (CtMethod test : testToBeSelected) {
             Set<String> tc = getTestCoverageFor(test);
@@ -78,7 +78,7 @@ public class TestSelector {
                 }
             }
         }
-        Set<CtMethod> testMethodsSelected = new HashSet<>();
+        List<CtMethod> testMethodsSelected = new ArrayList<>();
         if (selectedTest.size() > maxNumberOfTest) {
             testMethodsSelected.addAll(reduceSelectedTest(selectedTest));
         } else {

--- a/src/main/java/fr/inria/diversify/dspot/TestSelector.java
+++ b/src/main/java/fr/inria/diversify/dspot/TestSelector.java
@@ -63,7 +63,7 @@ public class TestSelector {
      * Tests are selected by the path they cover
      * If a path is already covered, the old test is replaced by the new one with 0.5 of probability
      */
-    public List<CtMethod> selectTests(Collection<CtMethod> oldTests, Collection<CtMethod> testToBeSelected) {
+    public List<CtMethod> selectTestToBeAmplified(Collection<CtMethod> oldTests, Collection<CtMethod> testToBeSelected) {
         Map<CtMethod, Set<String>> selectedTest = new HashMap<>();
         for (CtMethod test : testToBeSelected) {
             Set<String> tc = getTestCoverageFor(test);
@@ -86,6 +86,18 @@ public class TestSelector {
         }
         updateOldMethods(oldTests);
         return testMethodsSelected;
+    }
+
+    public Collection<CtMethod> selectTestAmongAmplifiedTests(Collection<CtMethod> tests) {
+        Map<CtMethod, Set<String>> amplifiedTests = new HashMap<>();
+        for (CtMethod test : tests) {
+            Set<String> tc = getTestCoverageFor(test);
+            Set<String> parentTc = getParentTestCoverageFor(test);
+            if (!tc.isEmpty() && !parentTc.containsAll(tc)) {
+                amplifiedTests.put(test, diff(tc, parentTc));
+            }
+        }
+        return reduceSelectedTest(amplifiedTests);
     }
 
     private void updateOldMethods(Collection<CtMethod> oldTests) {
@@ -118,18 +130,6 @@ public class TestSelector {
             return 3;
         }
         return 0;
-    }
-
-    public Collection<CtMethod> selectedAmplifiedTests(Collection<CtMethod> tests) {
-        Map<CtMethod, Set<String>> amplifiedTests = new HashMap<>();
-        for (CtMethod test : tests) {
-            Set<String> tc = getTestCoverageFor(test);
-            Set<String> parentTc = getParentTestCoverageFor(test);
-            if (!tc.isEmpty() && !parentTc.containsAll(tc)) {
-                amplifiedTests.put(test, diff(tc, parentTc));
-            }
-        }
-        return reduceSelectedTest(amplifiedTests);
     }
 
     private Collection<CtMethod> reduceSelectedTest(Map<CtMethod, Set<String>> selected) {

--- a/src/main/java/fr/inria/diversify/dspot/amp/StatementAdderOnAssert.java
+++ b/src/main/java/fr/inria/diversify/dspot/amp/StatementAdderOnAssert.java
@@ -312,6 +312,7 @@ public class StatementAdderOnAssert implements Amplifier {
         return literalsByMethod.get(method);
     }
 
+    //TODO Remove dependencies to the Coverage???
     public void reset(Coverage coverage, CtType testClass) {
         AmplificationHelper.reset();
         literalsByMethod = new HashMap<>();

--- a/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertGenerator.java
+++ b/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertGenerator.java
@@ -51,7 +51,7 @@ public class AssertGenerator {
                 amplifiedTestWithAssertion.add(ampTest);
             }
         }
-        Log.debug("{} test method(s) has been successfully generated", amplifiedTestWithAssertion.size());
+        Log.debug("{} new tests with assertions generated", amplifiedTestWithAssertion.size());
         return amplifiedTestWithAssertion;
     }
 

--- a/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertGenerator.java
+++ b/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertGenerator.java
@@ -56,7 +56,7 @@ public class AssertGenerator {
     }
 
     private List<Integer> findStatementToAssert(CtMethod test, Map<CtMethod, CtMethod> parentTest) {
-        if(!parentTest.isEmpty() && parentTest.get(test) != null) {
+        if(parentTest != null && !parentTest.isEmpty() && parentTest.get(test) != null) {
             CtMethod parent = parentTest.get(test);
             while (parentTest.get(parent) != null) {
                 parent = parentTest.get(parent);

--- a/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertGenerator.java
+++ b/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertGenerator.java
@@ -56,7 +56,7 @@ public class AssertGenerator {
     }
 
     private List<Integer> findStatementToAssert(CtMethod test, Map<CtMethod, CtMethod> parentTest) {
-        if(!parentTest.isEmpty()) {
+        if(!parentTest.isEmpty() && parentTest.get(test) != null) {
             CtMethod parent = parentTest.get(test);
             while (parentTest.get(parent) != null) {
                 parent = parentTest.get(parent);

--- a/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertGenerator.java
+++ b/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertGenerator.java
@@ -25,9 +25,9 @@ import java.util.stream.Collectors;
  */
 public class AssertGenerator {
 
-    protected DiversifyClassLoader applicationClassLoader;
-    protected InputProgram inputProgram;
-    protected DSpotCompiler compiler;
+    private DiversifyClassLoader applicationClassLoader;
+    private InputProgram inputProgram;
+    private DSpotCompiler compiler;
 
 
     public AssertGenerator(InputProgram inputProgram, DSpotCompiler compiler, DiversifyClassLoader applicationClassLoader) {
@@ -55,8 +55,8 @@ public class AssertGenerator {
         return amplifiedTestWithAssertion;
     }
 
-    protected List<Integer> findStatementToAssert(CtMethod test, Map<CtMethod, CtMethod> parentTest) {
-        if (parentTest != null) {
+    private List<Integer> findStatementToAssert(CtMethod test, Map<CtMethod, CtMethod> parentTest) {
+        if(!parentTest.isEmpty()) {
             CtMethod parent = parentTest.get(test);
             while (parentTest.get(parent) != null) {
                 parent = parentTest.get(parent);
@@ -67,7 +67,7 @@ public class AssertGenerator {
         }
     }
 
-    protected List<Integer> findStatementToAssertOnlyInvocation(CtMethod test) {
+    private List<Integer> findStatementToAssertOnlyInvocation(CtMethod test) {
         List<CtStatement> stmts = Query.getElements(test, new TypeFilter(CtStatement.class));
         List<Integer> indexs = new ArrayList<>();
         for (int i = 0; i < stmts.size(); i++) {
@@ -78,7 +78,7 @@ public class AssertGenerator {
         return indexs;
     }
 
-    protected List<Integer> findStatementToAssertFromParent(CtMethod test, CtMethod parentTest) {
+    private List<Integer> findStatementToAssertFromParent(CtMethod test, CtMethod parentTest) {
         List<CtStatement> originalStmts = Query.getElements(parentTest, new TypeFilter(CtStatement.class));
         List<String> originalStmtStrings = originalStmts.stream()
                 .map(stmt -> stmt.toString())

--- a/src/main/java/fr/inria/diversify/dspot/assertGenerator/MethodAssertGenerator.java
+++ b/src/main/java/fr/inria/diversify/dspot/assertGenerator/MethodAssertGenerator.java
@@ -167,7 +167,7 @@ public class MethodAssertGenerator {
     }
 
     protected CtMethod buildTestWithAssert(Map<String, Observation> observations) {
-        CtMethod testWithAssert = getFactory().Core().clone(test);
+        CtMethod testWithAssert = test.clone();
         // add throws
         List<CtStatement> statements = Query.getElements(testWithAssert, new TypeFilter(CtStatement.class));
         for(String id : observations.keySet()) {

--- a/src/main/java/fr/inria/diversify/mutant/MutantGenerator.java
+++ b/src/main/java/fr/inria/diversify/mutant/MutantGenerator.java
@@ -234,6 +234,7 @@ public class MutantGenerator {
     private void compileClasses() throws InterruptedException, IOException {
         String[] phases = new String[]{"clean", "test-compile"};
         MavenBuilder builder = new MavenBuilder(inputProgram.getProgramDir());
+        builder.setBuilderPath(inputConfiguration.getProperty("maven.home", null));
         builder.setGoals(phases);
         builder.initTimeOut();
     }

--- a/src/test/java/fr/inria/diversify/dspot/DSpotTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/DSpotTest.java
@@ -37,7 +37,7 @@ public class DSpotTest {
         DSpot dspot = new DSpot(configuration);
 
         CtType amplifiedTest = dspot.amplifyTest("example.TestSuiteExample");
-        assertEquals(20, amplifiedTest.getMethods().size());
+        assertEquals(28, amplifiedTest.getMethods().size());
         assertEquals(originalTestBody, amplifiedTest.getMethod("test1").getBody().toString());
         assertEquals(expectedAmplifiedBody, amplifiedTest.getMethod("test1_cf24").getBody().toString());
     }

--- a/src/test/java/fr/inria/diversify/dspot/amp/TestMethodCallAdderTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/amp/TestMethodCallAdderTest.java
@@ -66,7 +66,8 @@ public class TestMethodCallAdderTest extends AbstractTest {
         methodCallAdder.reset(null, null);
 
         final CtMethod<?> originalMethod = testClass.getMethods().stream().filter(m -> "testAddCall".equals(m.getSimpleName())).findFirst().get();
-        CtMethod amplifiedMethod = methodCallAdder.applyRandom(originalMethod);
+        CtMethod amplifiedMethod = originalMethod.clone();
+        amplifiedMethod = methodCallAdder.applyRandom(originalMethod);
 
         assertEquals(originalMethod.getBody().getStatements().size() + 1, amplifiedMethod.getBody().getStatements().size());
         CtStatement expectedStatement = originalMethod.getBody().getStatements().get(2);
@@ -87,6 +88,7 @@ public class TestMethodCallAdderTest extends AbstractTest {
         assertEquals(expectedStatement, amplifiedMethod.getBody().getStatements().get(2));
 
         // stack random amplification
+        amplifiedMethod.setParent(originalMethod.getParent());
         CtMethod stackedAmplifiedMethod = methodCallAdder.applyRandom(amplifiedMethod);
         assertEquals(amplifiedMethod.getBody().getStatements().size() + 1, stackedAmplifiedMethod.getBody().getStatements().size());
         assertEquals(originalMethod.getBody().getStatements().size() + 2, stackedAmplifiedMethod.getBody().getStatements().size());

--- a/src/test/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorTest.java
@@ -2,6 +2,7 @@ package fr.inria.diversify.dspot.assertGenerator;
 
 import fr.inria.diversify.buildSystem.android.InvalidSdkException;
 import fr.inria.diversify.dspot.AbstractTest;
+import fr.inria.diversify.dspot.AmplificationHelper;
 import org.junit.Test;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
@@ -27,7 +28,7 @@ public class AssertGeneratorTest extends AbstractTest {
         CtClass testClass = fr.inria.diversify.Utils.findClass("fr.inria.sample.TestClassWithoutAssert");
         AssertGenerator assertGenerator = new AssertGenerator(fr.inria.diversify.Utils.getInputProgram(), fr.inria.diversify.Utils.getCompiler(), fr.inria.diversify.Utils.getApplicationClassLoader());
 
-        CtType ctType = assertGenerator.generateAsserts(testClass);
+        CtType ctType = AmplificationHelper.addAmplifiedTestToClass(assertGenerator.generateAsserts(testClass), testClass);
 
         String nl = System.getProperty("line.separator");
 

--- a/src/test/java/fr/inria/diversify/mutant/MutantGeneratorTest.java
+++ b/src/test/java/fr/inria/diversify/mutant/MutantGeneratorTest.java
@@ -7,6 +7,7 @@ import fr.inria.diversify.dspot.DSpot;
 import fr.inria.diversify.dspot.amp.Amplifier;
 import fr.inria.diversify.dspot.amp.TestDataMutator;
 import fr.inria.diversify.runner.InputConfiguration;
+import fr.inria.diversify.util.Log;
 import fr.inria.diversify.util.PrintClassUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -64,7 +65,7 @@ public class MutantGeneratorTest {
         MutantRunResults mutantResultsWithAmplifiedTests = mutantGenerator.runTestsOnAliveMutant(new InputConfiguration(pathToPropertiesFile));
         assertTrue(mutantsNotKilled.size() > mutantResultsWithAmplifiedTests.getRemainsAliveMutant().size());
         assertEquals(mutantsNotKilled.size(), mutantResultsWithAmplifiedTests.getRemainsAliveMutant().size() +
-            mutantResultsWithAmplifiedTests.getKilledMutants().size());
+                mutantResultsWithAmplifiedTests.getKilledMutants().size());
 
         PrintClassUtils.printJavaFile(outputDirectory, exampleOriginalTestClass);
     }
@@ -94,17 +95,22 @@ public class MutantGeneratorTest {
             //ignored
         }
         final String mavenHome = Utils.buildMavenHome();
-        if (mavenHome != null) {
-            try(FileWriter writer = new FileWriter(pathToPropertiesFile, true)) {
-                writer.write(nl + "maven.home=" + mavenHome + nl);
-            } catch (IOException ignored) {
-                //ignored
-            }
+        Log.debug("Maven Home: {}", mavenHome);
+        try (FileWriter writer = new FileWriter(pathToPropertiesFile, true)) {
+            writer.write(nl + "maven.home=" + mavenHome + nl);
+        } catch (IOException ignored) {
+            throw new RuntimeException(ignored);
+            //ignored
+        }
+        try (BufferedReader buffer = new BufferedReader(new FileReader(pathToPropertiesFile))) {
+            System.out.println(buffer.lines().collect(Collectors.joining(nl)));
+        } catch (IOException ignored) {
+            //ignored
         }
     }
 
     private void removeHomFromPropertiesFile() {
-        try(FileWriter writer = new FileWriter(pathToPropertiesFile, false)) {
+        try (FileWriter writer = new FileWriter(pathToPropertiesFile, false)) {
             writer.write(originalProperties);
         } catch (IOException ignored) {
             //ignored


### PR DESCRIPTION
Refactor the amplification loop.

Next step is the refactor of the test selector. We need an interface and remove dependencies between test selector and amplifier. We will be able to add easily pit mutation coverage selection after that (almost done in local).