### PR TITLE
Improve pit runner

### DIFF
--- a/src/main/java/fr/inria/diversify/dspot/AmplificationHelper.java
+++ b/src/main/java/fr/inria/diversify/dspot/AmplificationHelper.java
@@ -2,6 +2,7 @@ package fr.inria.diversify.dspot;
 
 import fr.inria.diversify.dspot.support.DSpotCompiler;
 import fr.inria.diversify.dspot.support.MavenDependenciesResolver;
+import fr.inria.diversify.mutant.pit.PitRunner;
 import fr.inria.diversify.runner.InputConfiguration;
 import fr.inria.diversify.runner.InputProgram;
 import fr.inria.diversify.testRunner.JunitResult;
@@ -25,6 +26,8 @@ import java.net.URLClassLoader;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static fr.inria.diversify.mutant.pit.PitRunner.PROPERTY_ADDITIONAL_CP_ELEMENTS;
 
 /**
  * Created by Benjamin DANGLOT
@@ -209,7 +212,9 @@ public class AmplificationHelper {
 
     public static String getDependenciesOf(InputConfiguration inputConfiguration, InputProgram inputProgram) {
         URL[] dependencies = MavenDependenciesResolver.resolveDependencies(inputConfiguration, inputProgram, DSpotUtils.buildMavenHome(inputConfiguration));
-        String dependenciesAsString = Arrays.stream(dependencies).reduce("", (acc, url) -> {
+        String dependenciesAsString = inputConfiguration.getProperty(PitRunner.PROPERTY_ADDITIONAL_CP_ELEMENTS) != null ?
+                inputConfiguration.getProperty(PitRunner.PROPERTY_ADDITIONAL_CP_ELEMENTS) : ""
+                + Arrays.stream(dependencies).reduce("", (acc, url) -> {
             try {
                 return acc + new File(url.toURI()).getAbsolutePath() + ":";
             } catch (URISyntaxException e) {

--- a/src/main/java/fr/inria/diversify/mutant/pit/PitRunner.java
+++ b/src/main/java/fr/inria/diversify/mutant/pit/PitRunner.java
@@ -31,23 +31,37 @@ public class PitRunner {
 
     private static final String OPT_TARGET_TESTS = "-DtargetTests=";
 
+    public static final String PROPERTY_ADDITIONAL_CP_ELEMENTS = "additionalClasspathElements";
+
+    private static final String PROPERTY_EXCLUDED_CLASSES = "excludedClasses";
+
+    private static final String OPT_ADDITIONAL_CP_ELEMENTS = "-D" + PROPERTY_ADDITIONAL_CP_ELEMENTS + "=";
+
+    private static final String OPT_EXCLUDED_CLASSES = "-D" + PROPERTY_EXCLUDED_CLASSES + "=";
+
     private static final String CMD_PIT_MUTATION_COVERAGE = "org.pitest:pitest-maven:mutationCoverage";
 
     public static List<PitResult> run(InputProgram program, InputConfiguration configuration, CtType testClass) {
         try {
-            ;
             long time = System.currentTimeMillis();
             String mavenHome = DSpotUtils.buildMavenHome(configuration);
             MavenBuilder builder = new MavenBuilder(program.getProgramDir());
             builder.setBuilderPath(mavenHome);
             String[] phases = new String[]{PRE_GOAL_PIT, //
+                    CMD_PIT_MUTATION_COVERAGE, //
                     OPT_WITH_HISTORY, //
                     OPT_VALUE_MUTATORS, //
                     OPT_TARGET_CLASSES + configuration.getProperty("filter"), //
                     OPT_VALUE_REPORT_DIR, //
                     OPT_VALUE_FORMAT, //
                     OPT_TARGET_TESTS + testClass.getQualifiedName(), //
-                    CMD_PIT_MUTATION_COVERAGE};
+                    configuration.getProperty(PROPERTY_ADDITIONAL_CP_ELEMENTS) != null ?
+                            OPT_ADDITIONAL_CP_ELEMENTS + configuration.getProperty(PROPERTY_ADDITIONAL_CP_ELEMENTS) :
+                            "", //
+                    configuration.getProperty(PROPERTY_EXCLUDED_CLASSES) != null ?
+                            OPT_EXCLUDED_CLASSES + configuration.getProperty(PROPERTY_EXCLUDED_CLASSES) :
+                            ""//
+            };
             builder.runGoals(phases, true);
             if (!new File(program.getProgramDir() + "/target/pit-reports").exists()) {
                 return null;
@@ -69,12 +83,19 @@ public class PitRunner {
             MavenBuilder builder = new MavenBuilder(program.getProgramDir());
             builder.setBuilderPath(mavenHome);
             String[] phases = new String[]{PRE_GOAL_PIT, //
+                    CMD_PIT_MUTATION_COVERAGE, //
                     OPT_WITH_HISTORY, //
                     OPT_VALUE_MUTATORS, //
                     OPT_TARGET_CLASSES + configuration.getProperty("filter"), //
                     OPT_VALUE_REPORT_DIR, //
                     OPT_VALUE_FORMAT, //
-                    CMD_PIT_MUTATION_COVERAGE};
+                    configuration.getProperty(PROPERTY_ADDITIONAL_CP_ELEMENTS) != null ?
+                            OPT_ADDITIONAL_CP_ELEMENTS + configuration.getProperty(PROPERTY_ADDITIONAL_CP_ELEMENTS) :
+                            "", //
+                    configuration.getProperty(PROPERTY_EXCLUDED_CLASSES) != null ?
+                            OPT_EXCLUDED_CLASSES + configuration.getProperty(PROPERTY_EXCLUDED_CLASSES) :
+                            ""//
+            };
             builder.runGoals(phases, true);
             File directoryReportPit = new File(program.getProgramDir() + "/target/pit-reports").listFiles()[0];
             List<PitResult> results = PitResultParser.parse(new File(directoryReportPit.getPath() + "/mutations.csv"));

--- a/src/main/java/fr/inria/stamp/JSAPOptions.java
+++ b/src/main/java/fr/inria/stamp/JSAPOptions.java
@@ -166,7 +166,7 @@ public class JSAPOptions {
         iteration.setAllowMultipleDeclarations(false);
         iteration.setHelp("[optional] specify the number of amplification iteration. A larger number may help to improve the test criterion (eg a larger number of iterations mah help to kill more mutants). This has an impact on the execution time: the more iterations, the longer DSpot runs.");
 
-        FlaggedOption selector = new FlaggedOption("testCriterion");
+        FlaggedOption selector = new FlaggedOption("test-criterion");
         selector.setAllowMultipleDeclarations(false);
         selector.setLongFlag("test-criterion");
         selector.setShortFlag('s');


### PR DESCRIPTION
 throught the InputConfiguration

support -DadditionnalClasspathElements and -DexcludedClasses in pit runner.

 -DexcludedClasses  will be use to discard test cases that are not passing from dspot, such as test that use relative path (until we find a fix).