### PR TITLE
feat: add MethodsAssertGenerator

### DIFF
--- a/src/main/java/fr/inria/diversify/dspot/AmplificationHelper.java
+++ b/src/main/java/fr/inria/diversify/dspot/AmplificationHelper.java
@@ -179,8 +179,8 @@ public class AmplificationHelper {
 
     public static char getRandomChar() {
         int value = getRandom().nextInt(94) + 32;
-        char c = (char) ((value == 34 || value == 39) ? value + (getRandom().nextBoolean() ? 1 : -1) : value);
-        return c;//excluding " and '
+        char c = (char) ((value == 34 || value == 39 || value == 92) ? value + (getRandom().nextBoolean() ? 1 : -1) : value);
+        return c;//discarding " ' and \
     }
 
     public static CtMethod<?> addOriginInComment(CtMethod<?> amplifiedTest, CtMethod<?> topParent) {

--- a/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorHelper.java
+++ b/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorHelper.java
@@ -1,0 +1,256 @@
+package fr.inria.diversify.dspot.assertGenerator;
+
+import fr.inria.diversify.dspot.AmplificationHelper;
+import fr.inria.diversify.dspot.DSpotUtils;
+import spoon.reflect.code.*;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.Query;
+import spoon.reflect.visitor.filter.TypeFilter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static fr.inria.diversify.dspot.AmplificationChecker.isAssert;
+
+/**
+ * Created by Benjamin DANGLOT
+ * benjamin.danglot@inria.fr
+ * on 3/3/17
+ */
+public class AssertGeneratorHelper {
+
+    static boolean isVoidReturn(CtInvocation invocation) {
+        return invocation.getType() != null && (invocation.getType().getSimpleName().equals("Void") || invocation.getType().getSimpleName().equals("void"));
+    }
+
+    static boolean isStmtToLog(String nameOfOriginalClass, CtStatement statement) {
+        if (!(statement.getParent() instanceof CtBlock)) {
+            return false;
+        }
+        if (statement instanceof CtInvocation) {
+            CtInvocation invocation = (CtInvocation) statement;
+
+            //type tested by the test class
+            String targetType = "";
+            if (invocation.getTarget() != null &&
+                    invocation.getTarget().getType() != null) {
+                targetType = invocation.getTarget().getType().getSimpleName();
+            }
+            return nameOfOriginalClass.startsWith(targetType)
+                    || !isVoidReturn(invocation);
+        }
+        return statement instanceof CtVariableWrite
+                || statement instanceof CtAssignment
+                || statement instanceof CtLocalVariable;
+    }
+
+
+    static CtMethod<?> createTestWithoutAssert(CtMethod<?> test, List<Integer> assertIndexToKeep) {
+        CtMethod newTest = test.clone();
+        newTest.setSimpleName(test.getSimpleName() + "_withoutAssert");
+        int stmtIndex = 0;
+        List<CtStatement> statements = Query.getElements(newTest, new TypeFilter(CtStatement.class));
+        for (CtStatement statement : statements) {
+            try {
+                if (!assertIndexToKeep.contains(stmtIndex) && isAssert(statement)) {
+                    CtBlock block = buildRemoveAssertBlock(test.getFactory(), (CtInvocation) statement, stmtIndex);
+                    if (statement.getParent() instanceof CtCase) {
+                        CtCase ctCase = (CtCase) statement.getParent();
+                        int index = ctCase.getStatements().indexOf(statement);
+                        ctCase.getStatements().add(index, block);
+                        ctCase.getStatements().remove(statement);
+                    } else {
+                        if (block.getStatements().size() == 0) {
+                            statement.delete();
+                        } else if (block.getStatements().size() == 1) {
+                            statement.replace(block.getStatement(0));
+                        } else {
+                            replaceStatementByListOfStatements(statement, block.getStatements());
+                        }
+                    }
+                }
+                stmtIndex++;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return newTest;
+    }
+
+    private static CtLocalVariable<Object> buildVarStatement(Factory factory, CtExpression arg, String id) {
+        CtTypeReference<Object> objectType = factory.Core().createTypeReference();
+        objectType.setSimpleName("Object");
+        CtLocalVariable<Object> localVar = factory.Code().createLocalVariable(objectType, "o_" + id, arg);
+        DSpotUtils.addComment(localVar, "MethodAssertGenerator build local variable", CtComment.CommentType.INLINE);
+        return localVar;
+    }
+
+    private static List<CtExpression> getNotLiteralArgs(CtInvocation invocation) {
+        List<CtExpression> args = invocation.getArguments();
+        return args.stream()
+                .filter(arg -> !(arg instanceof CtLiteral))
+                .collect(Collectors.toList());
+    }
+
+    static void replaceStatementByListOfStatements(CtStatement statement, List<CtStatement> statements) {
+        String oldStatement = statement.toString();
+        statement.replace(statements.get(0));
+        for (int i = 1; i < statements.size(); i++) {
+            statement.insertAfter(statements.get(i));
+        }
+        DSpotUtils.addComment(statement, "MethodAssertion Generator replaced " + oldStatement, CtComment.CommentType.BLOCK);
+    }
+
+    static CtBlock buildRemoveAssertBlock(Factory factory, CtInvocation assertInvocation, int blockId) {
+        CtBlock block = factory.Core().createBlock();
+        int[] idx = {0};
+        getNotLiteralArgs(assertInvocation).stream()
+                .filter(arg -> !(arg instanceof CtVariableAccess))
+                .map(arg -> buildVarStatement(factory, arg, blockId + "_" + (idx[0]++)))
+                .forEach(stmt -> block.addStatement(stmt));
+
+        block.setParent(assertInvocation.getParent());
+        return block;
+    }
+
+    static void addLogStmt(CtStatement stmt, String id, boolean forAssert) {
+        if (stmt instanceof CtLocalVariable && ((CtLocalVariable) stmt).getDefaultExpression() == null) {
+            return;
+        }
+        String snippet;
+        if (forAssert) {
+            snippet = "fr.inria.diversify.compare.ObjectLog.log(";
+        } else {
+            snippet = "fr.inria.diversify.compare.ObjectLog.logObject(";
+        }
+
+        CtStatement insertAfter = null;
+        if (stmt instanceof CtVariableWrite) {
+            CtVariableWrite varWrite = (CtVariableWrite) stmt;
+            snippet += varWrite.getVariable()
+                    + ",\"" + varWrite.getVariable() + "\",\"" + id + "\")";
+            insertAfter = stmt;
+        }
+        if (stmt instanceof CtLocalVariable) {
+            CtLocalVariable localVar = (CtLocalVariable) stmt;
+            snippet += localVar.getSimpleName()
+                    + ",\"" + localVar.getSimpleName() + "\",\"" + id + "\")";
+            insertAfter = stmt;
+        }
+        if (stmt instanceof CtAssignment) {
+            CtAssignment localVar = (CtAssignment) stmt;
+            snippet += localVar.getAssigned()
+                    + ",\"" + localVar.getAssigned() + "\",\"" + id + "\")";
+            insertAfter = stmt;
+        }
+
+        if (stmt instanceof CtInvocation) {
+            CtInvocation invocation = (CtInvocation) stmt;
+            if (isVoidReturn(invocation)) {
+                insertAfter = invocation;
+                snippet += invocation.getTarget()
+                        + ",\"" + invocation.getTarget() + "\",\"" + id + "\")";
+            } else {
+                String snippetStmt = "Object o_" + id + " = " + invocation.toString();
+                CtStatement localVarSnippet = stmt.getFactory().Code().createCodeSnippetStatement(snippetStmt);
+                stmt.replace(localVarSnippet);
+                insertAfter = localVarSnippet;
+
+                snippet += "o_" + id
+                        + ",\"o_" + id + "\",\"" + id + "\")";
+
+            }
+        }
+        CtStatement logStmt = stmt.getFactory().Code().createCodeSnippetStatement(snippet);
+        insertAfter.insertAfter(logStmt);
+    }
+
+    static CtLocalVariable<Object> buildVarStatement(CtExpression arg, String id) {
+        CtTypeReference<Object> objectType = arg.getFactory().Core().createTypeReference();
+        objectType.setSimpleName("Object");
+        CtLocalVariable<Object> localVar = arg.getFactory().Code().createLocalVariable(objectType, "o_" + id, arg);
+        DSpotUtils.addComment(localVar, "MethodAssertGenerator build local variable", CtComment.CommentType.INLINE);
+        return localVar;
+    }
+
+    static Map<CtMethod<?>, List<Integer>> takeAllStatementToAssert(CtType testClass, List<CtMethod<?>> tests) {
+        return tests.stream()
+                .collect(Collectors.toMap(Function.identity(),
+                        ctMethod -> {
+                            List<Integer> indices = new ArrayList<>();
+                            for (int i = 0; i < Query.getElements(testClass, new TypeFilter(CtStatement.class)).size(); i++) {
+                                indices.add(i);
+                            }
+                            return indices;
+                        }
+                ));
+    }
+
+    static List<Integer> findStatementToAssert(CtMethod<?> test) {
+        if (AmplificationHelper.getAmpTestToParent() != null
+                && !AmplificationHelper.getAmpTestToParent().isEmpty()
+                && AmplificationHelper.getAmpTestToParent().get(test) != null) {
+            CtMethod parent = AmplificationHelper.getAmpTestToParent().get(test);
+            while (AmplificationHelper.getAmpTestToParent().get(parent) != null) {
+                parent = AmplificationHelper.getAmpTestToParent().get(parent);
+            }
+            return findStatementToAssertFromParent(test, parent);
+        } else {
+            return findStatementToAssertOnlyInvocation(test);
+        }
+    }
+
+    static List<Integer> findStatementToAssertOnlyInvocation(CtMethod<?> test) {
+        List<CtStatement> stmts = Query.getElements(test, new TypeFilter(CtStatement.class));
+        List<Integer> indexs = new ArrayList<>();
+        for (int i = 0; i < stmts.size(); i++) {
+            if (CtInvocation.class.isInstance(stmts.get(i))) {
+                indexs.add(i);
+            }
+        }
+        return indexs;
+    }
+
+    static List<Integer> findStatementToAssertFromParent(CtMethod<?> test, CtMethod<?> parentTest) {
+        List<CtStatement> originalStmts = Query.getElements(parentTest, new TypeFilter(CtStatement.class));
+        List<String> originalStmtStrings = originalStmts.stream()
+                .map(Object::toString)
+                .collect(Collectors.toList());
+
+        List<CtStatement> ampStmts = Query.getElements(test, new TypeFilter(CtStatement.class));
+        List<String> ampStmtStrings = ampStmts.stream()
+                .map(Object::toString)
+                .collect(Collectors.toList());
+
+        List<Integer> indices = new ArrayList<>();
+        for (int i = 0; i < ampStmtStrings.size(); i++) {
+            int index = originalStmtStrings.indexOf(ampStmtStrings.get(i));
+            if (index == -1) {
+                indices.add(i);
+            } else {
+                originalStmtStrings.remove(index);
+            }
+        }
+        return indices;
+    }
+
+    static CtMethod<?> createTestWithLog(CtMethod test, List<Integer> statementsIndexToAssert, String nameOfClass) {
+        CtMethod newTest = test.clone();
+        newTest.setSimpleName(test.getSimpleName() + "_withlog");
+        List<CtStatement> stmts = Query.getElements(newTest, new TypeFilter(CtStatement.class));
+        for (int i = 0; i < stmts.size(); i++) {
+            CtStatement stmt = stmts.get(i);
+            if (isStmtToLog(nameOfClass, stmt)) {
+                addLogStmt(stmt, test.getSimpleName() + "__" + i, statementsIndexToAssert != null && statementsIndexToAssert.contains(i));
+            }
+        }
+        return newTest;
+    }
+
+}

--- a/src/main/java/fr/inria/diversify/dspot/assertGenerator/MethodsAssertGenerator.java
+++ b/src/main/java/fr/inria/diversify/dspot/assertGenerator/MethodsAssertGenerator.java
@@ -1,0 +1,269 @@
+package fr.inria.diversify.dspot.assertGenerator;
+
+import fr.inria.diversify.compare.ObjectLog;
+import fr.inria.diversify.compare.Observation;
+import fr.inria.diversify.dspot.AmplificationHelper;
+import fr.inria.diversify.dspot.DSpotUtils;
+import fr.inria.diversify.dspot.support.Counter;
+import fr.inria.diversify.dspot.support.DSpotCompiler;
+import fr.inria.diversify.runner.InputProgram;
+import fr.inria.diversify.testRunner.JunitResult;
+import fr.inria.diversify.testRunner.TestCompiler;
+import fr.inria.diversify.testRunner.TestRunner;
+import fr.inria.diversify.util.Log;
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+import spoon.reflect.code.*;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.Query;
+import spoon.reflect.visitor.filter.TypeFilter;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static fr.inria.diversify.dspot.assertGenerator.AssertGeneratorHelper.takeAllStatementToAssert;
+
+/**
+ * Created by Benjamin DANGLOT
+ * benjamin.danglot@inria.fr
+ * on 3/3/17
+ */
+public class MethodsAssertGenerator {
+
+    private int numberOfFail = 0;
+
+    private CtType originalClass;
+
+    private Factory factory;
+
+    private InputProgram inputProgram;
+
+    private DSpotCompiler compiler;
+
+    public MethodsAssertGenerator(CtType originalClass, InputProgram inputProgram, DSpotCompiler compiler) {
+        this.originalClass = originalClass;
+        this.inputProgram = inputProgram;
+        this.compiler = compiler;
+        this.factory = inputProgram.getFactory();
+    }
+
+    public List<CtMethod<?>> generateAsserts(CtType testClass, List<CtMethod<?>> tests) throws IOException, ClassNotFoundException {
+        final Map<CtMethod<?>, List<Integer>> statementsIndexToAssert = takeAllStatementToAssert(testClass, tests);
+        final List<CtMethod<?>> testWithoutAssert = tests.stream()
+                .map(test -> AssertGeneratorHelper.createTestWithoutAssert(test, statementsIndexToAssert.get(test)))
+                .collect(Collectors.toList());
+        return generateAsserts(testClass,
+                testWithoutAssert,
+                takeAllStatementToAssert(testClass, testWithoutAssert));
+    }
+
+    public List<CtMethod<?>> generateAsserts(CtType testClass, List<CtMethod<?>> tests, Map<CtMethod<?>, List<Integer>> statementsIndexToAssert) throws IOException, ClassNotFoundException {
+        CtType clone = testClass.clone();
+        testClass.getPackage().addType(clone);
+        tests.forEach(clone::addMethod);
+        final JunitResult result = runTests(clone, tests);
+        if (result == null || result.getTestRuns().size() != tests.size()) {
+            return Collections.EMPTY_LIST;
+        } else {
+
+            final List<String> failuresMethodName = result.getFailures().stream()
+                    .collect(ArrayList<String>::new,
+                            (methodNames, failure) ->
+                                    methodNames.add(failure.getDescription().getMethodName()),
+                            ArrayList<String>::addAll);
+
+            // add assertion on passing tests
+            List<CtMethod<?>> passingTests = addAssertions(clone,
+                    tests.stream()
+                            .filter(ctMethod -> !failuresMethodName.contains(ctMethod.getSimpleName()))
+                            .collect(Collectors.toList()),
+                    statementsIndexToAssert)
+                    .stream()
+                    .filter(ctMethod -> ctMethod != null)
+                    .collect(Collectors.toList());
+
+            // add try/catch/fail on failing/error tests
+            List<CtMethod<?>> failingTests = tests.stream()
+                    .filter(ctMethod -> failuresMethodName
+                            .contains(ctMethod.getSimpleName()))
+                    .map(ctMethod -> makeFailureTest(ctMethod,
+                            result.getFailures().stream()
+                                    .filter(failure ->
+                                            failure.getDescription().getMethodName().contains(ctMethod.getSimpleName()))
+                                    .findFirst()
+                                    .get()))
+                    .filter(ctMethod -> ctMethod != null)
+                    .collect(Collectors.toList());
+
+            if (passingTests != null) {
+                passingTests.addAll(failingTests);
+            } else {
+                passingTests = failingTests;
+            }
+            return filterTest(passingTests);
+        }
+    }
+
+
+    private List<CtMethod<?>> addAssertions(CtType testClass, List<CtMethod<?>> testCases, Map<CtMethod<?>, List<Integer>> statementsIndexToAssert) throws IOException, ClassNotFoundException {
+        final List<CtMethod<?>> testCasesWithLogs = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            int finalI = i;
+            final List<? extends CtMethod<?>> testsWithLog = testCases.stream()
+                    .map(ctMethod -> AssertGeneratorHelper.createTestWithLog(ctMethod, statementsIndexToAssert.get(ctMethod), this.originalClass.getSimpleName()))
+                    .map(ctMethod -> {
+                        ctMethod.setSimpleName(ctMethod.getSimpleName() + finalI);
+                        return ctMethod;
+                    })
+                    .collect(Collectors.toList());
+            testsWithLog.forEach(testClass::addMethod);
+            testCasesWithLogs.addAll(testsWithLog);
+        }
+        ObjectLog.reset();
+        final JunitResult result = runTests(testClass, testCasesWithLogs);
+        if (result == null || !result.getFailures().isEmpty()) {
+            return Collections.EMPTY_LIST;
+        } else {
+            return testCases.stream()
+                    .map(ctMethod -> this.buildTestWithAssert(ctMethod, ObjectLog.getObservations()))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    private CtMethod<?> buildTestWithAssert(CtMethod test, Map<String, Observation> observations) {
+        CtMethod testWithAssert = test.clone();
+        int numberOfAddedAssertion = 0;
+        List<CtStatement> statements = Query.getElements(testWithAssert, new TypeFilter(CtStatement.class));
+        for (String id : observations.keySet()) {
+            if (!id.startsWith(testWithAssert.getSimpleName())) {
+                continue;
+            }
+            int line = Integer.parseInt(id.split("__")[1]);
+            List<String> asserts = observations.get(id).buildAssert();
+            for (String snippet : asserts) {
+                CtStatement assertStmt = factory.Code().createCodeSnippetStatement(snippet);
+                DSpotUtils.addComment(assertStmt, "AssertGenerator add assertion", CtComment.CommentType.INLINE);
+                try {
+                    CtStatement stmt = statements.get(line);
+                    if (stmt instanceof CtInvocation && !AssertGeneratorHelper.isVoidReturn((CtInvocation) stmt)) {
+                        String localVarSnippet = ((CtInvocation) stmt).getType().toString()
+                                + " o_" + id + " = "
+                                + stmt.toString();
+                        CtStatement localVarStmt = factory.Code().createCodeSnippetStatement(localVarSnippet);
+                        stmt.replace(localVarStmt);
+                        statements.set(line, localVarStmt);
+                        DSpotUtils.addComment(localVarStmt, "AssertGenerator replace invocation", CtComment.CommentType.INLINE);
+                        localVarStmt.setParent(stmt.getParent());
+                        localVarStmt.insertAfter(assertStmt);
+                    } else {
+                        stmt.insertAfter(assertStmt);
+                    }
+                    numberOfAddedAssertion++;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        Counter.updateAssertionOf(testWithAssert, numberOfAddedAssertion);
+        if (!testWithAssert.equals(test)) {
+            AmplificationHelper.getAmpTestToParent().put(testWithAssert, test);
+            return testWithAssert;
+        } else {
+            return null;
+        }
+    }
+
+    protected CtMethod<?> makeFailureTest(CtMethod<?> test, Failure failure) {
+        CtMethod testWithoutAssert = AssertGeneratorHelper.createTestWithoutAssert(test, new ArrayList<>());
+        testWithoutAssert.setSimpleName(test.getSimpleName());
+        Factory factory = testWithoutAssert.getFactory();
+
+        Throwable exception = failure.getException();
+        if (exception instanceof AssertionError) {
+            exception = exception.getCause();
+        }
+        Class exceptionClass;
+        if (exception == null) {
+            exceptionClass = Exception.class;
+        } else {
+            exceptionClass = exception.getClass();
+        }
+
+        CtTry tryBlock = factory.Core().createTry();
+        tryBlock.setBody(testWithoutAssert.getBody());
+        String snippet = "org.junit.Assert.fail(\"" + test.getSimpleName() + " should have thrown " + exceptionClass.getSimpleName() + "\")";
+        tryBlock.getBody().addStatement(factory.Code().createCodeSnippetStatement(snippet));
+        DSpotUtils.addComment(tryBlock, "AssertGenerator generate try/catch block with fail statement", CtComment.CommentType.INLINE);
+
+        CtCatch ctCatch = factory.Core().createCatch();
+        CtTypeReference exceptionType = factory.Type().createReference(exceptionClass);
+        ctCatch.setParameter(factory.Code().createCatchVariable(exceptionType, "eee"));
+
+        ctCatch.setBody(factory.Core().createBlock());
+
+        List<CtCatch> catchers = new ArrayList<>(1);
+        catchers.add(ctCatch);
+        tryBlock.setCatchers(catchers);
+
+        CtBlock body = factory.Core().createBlock();
+        body.addStatement(tryBlock);
+
+        testWithoutAssert.setBody(body);
+        testWithoutAssert.setSimpleName(testWithoutAssert.getSimpleName() + "_failAssert" + (numberOfFail++));
+        Counter.updateAssertionOf(testWithoutAssert, 1);
+
+        AmplificationHelper.getAmpTestToParent().put(testWithoutAssert, test);
+
+        return testWithoutAssert;
+    }
+
+    private JunitResult runTests(CtType testClass, List<CtMethod<?>> testsToRun) {
+        boolean statusCompilation = TestCompiler.writeAndCompile(this.compiler, testClass, true,
+                inputProgram.getProgramDir() + "/" + inputProgram.getClassesDir() + ":" +
+                        inputProgram.getProgramDir() + "/" + inputProgram.getTestClassesDir());
+        if (!statusCompilation) {
+            return null;
+        } else {
+            String classpath = AmplificationHelper.getClassPath(this.compiler, this.inputProgram);
+            return TestRunner.runTests(testClass, testsToRun, classpath, this.inputProgram);
+        }
+    }
+
+    private List<CtMethod<?>> filterTest(List<CtMethod<?>> tests) {
+        CtType clone = this.originalClass.clone();
+        this.originalClass.getPackage().addType(clone);
+        final ArrayList<CtMethod<?>> clones = tests.stream()
+                .collect(ArrayList<CtMethod<?>>::new,
+                        (listClones, ctMethod) -> listClones.add(ctMethod.clone()),
+                        ArrayList<CtMethod<?>>::addAll);
+        clones.forEach(clone::addMethod);
+
+        // here, we run 3 times each test cases in case of randomness
+        for (int i = 0; i < 3; i++) {
+            final JunitResult result = runTests(clone, clones);
+            if (result == null) {
+                return Collections.emptyList();
+            } else {
+                final ArrayList<String> failingTestHeaders = result.getFailures().stream()
+                        .collect(ArrayList<String>::new,
+                                (testHeaders, failure) -> testHeaders.add(failure.getTestHeader().split("\\(")[0]),
+                                ArrayList<String>::addAll);
+                failingTestHeaders.forEach(failingTestHeader -> {
+                            final CtMethod<?> failingTestCase = clones.stream()
+                                    .filter(ctMethod ->
+                                            ctMethod.getSimpleName().equals(failingTestHeader))
+                                    .findFirst()
+                                    .get();
+                            clones.remove(failingTestCase);
+                            clone.removeMethod(failingTestCase);
+                        }
+                );
+            }
+        }
+        return clones;
+    }
+}

--- a/src/test/java/fr/inria/diversify/dspot/assertGenerator/MethodsAssertGeneratorTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/assertGenerator/MethodsAssertGeneratorTest.java
@@ -1,0 +1,59 @@
+package fr.inria.diversify.dspot.assertGenerator;
+
+import fr.inria.diversify.Utils;
+import fr.inria.diversify.buildSystem.android.InvalidSdkException;
+import fr.inria.diversify.dspot.AbstractTest;
+import org.junit.Test;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static fr.inria.diversify.dspot.assertGenerator.AssertGeneratorHelper.findStatementToAssert;
+import static junit.framework.TestCase.assertEquals;
+
+/**
+ * Created by Benjamin DANGLOT
+ * benjamin.danglot@inria.fr
+ * on 3/4/17
+ */
+public class MethodsAssertGeneratorTest extends AbstractTest {
+
+    @Test
+    public void testBuildNewAssert() throws InvalidSdkException, Exception {
+        CtClass testClass = Utils.findClass("fr.inria.sample.TestClassWithoutAssert");
+        MethodsAssertGenerator mag = new MethodsAssertGenerator(testClass, Utils.getInputProgram(), Utils.getCompiler());
+
+        String nl = System.getProperty("line.separator");
+
+        final String expectedBody = "{" + nl +
+                "    fr.inria.sample.ClassWithBoolean cl = new fr.inria.sample.ClassWithBoolean();" + nl +
+                "    // AssertGenerator add assertion" + nl +
+                "    org.junit.Assert.assertFalse(((fr.inria.sample.ClassWithBoolean)cl).getFalse());" + nl +
+                "    // AssertGenerator add assertion" + nl +
+                "    org.junit.Assert.assertTrue(((fr.inria.sample.ClassWithBoolean)cl).getTrue());" + nl +
+                "    // AssertGenerator add assertion" + nl +
+                "    org.junit.Assert.assertTrue(((fr.inria.sample.ClassWithBoolean)cl).getBoolean());" + nl +
+                "    // AssertGenerator replace invocation" + nl +
+                "    boolean o_test1_withoutAssert__3 = cl.getFalse();" + nl +
+                "    // AssertGenerator add assertion" + nl +
+                "    org.junit.Assert.assertFalse(o_test1_withoutAssert__3);" + nl +
+                "    // AssertGenerator replace invocation" + nl +
+                "    boolean o_test1_withoutAssert__4 = cl.getBoolean();" + nl +
+                "    // AssertGenerator add assertion" + nl +
+                "    org.junit.Assert.assertTrue(o_test1_withoutAssert__4);" + nl +
+                "    boolean var = cl.getTrue();" + nl +
+                "    // AssertGenerator add assertion" + nl +
+                "    org.junit.Assert.assertTrue(var);" + nl +
+                "}";
+
+        CtMethod test1 = Utils.findMethod("fr.inria.sample.TestClassWithoutAssert", "test1");
+
+        List<CtMethod<?>> test1_buildNewAssert = mag.generateAsserts(testClass, Collections.singletonList(test1));
+
+        assertEquals(expectedBody, test1_buildNewAssert.get(0).getBody().toString());
+    }
+
+}

--- a/src/test/java/fr/inria/stamp/MainTest.java
+++ b/src/test/java/fr/inria/stamp/MainTest.java
@@ -24,6 +24,7 @@ public class MainTest extends MavenAbstractTest {
                 "--test-criterion", "BranchCoverageTestSelector",
                 "--amplifiers", "MethodAdd:TestDataMutator:StatementAdderOnAssert",
                 "--iteration", "1",
+                "--randomSeed", "72"
         }));
         final File reportFile = new File("dspot-out/example.TestSuiteExample_branch_coverage_report.txt");
         assertTrue(reportFile.exists());


### PR DESCRIPTION
Compiling and running all the generated test case, and not one by one (such as the MethodAssertGenerator).

On DSpotTest, it decreases the computation time from 3s to 1.3s

Adds a AssertGeneratorHelper
