### PR TITLE
Fix assertgenerator

### DIFF
--- a/src/main/java/fr/inria/diversify/dspot/Amplification.java
+++ b/src/main/java/fr/inria/diversify/dspot/Amplification.java
@@ -2,6 +2,7 @@ package fr.inria.diversify.dspot;
 
 import fr.inria.diversify.dspot.amplifier.Amplifier;
 import fr.inria.diversify.dspot.assertGenerator.AssertGenerator;
+import fr.inria.diversify.dspot.assertGenerator.AssertGeneratorHelper;
 import fr.inria.diversify.dspot.selector.TestSelector;
 import fr.inria.diversify.dspot.support.DSpotCompiler;
 import fr.inria.diversify.runner.InputProgram;
@@ -92,7 +93,7 @@ public class Amplification {
             }
             Log.debug("{} tests selected to be amplified over {} available tests", testToBeAmplified.size(), currentTestList.size());
 
-            currentTestList = reduce(amplifyTests(testToBeAmplified));
+            currentTestList = AmplificationHelper.reduce(amplifyTests(testToBeAmplified));
 
             List<CtMethod<?>> testWithAssertions = assertGenerator.generateAsserts(classTest, currentTestList);
             if (testWithAssertions.isEmpty()) {
@@ -186,21 +187,6 @@ public class Amplification {
                 .map(amplifiedTest ->
                         AmplificationHelper.addOriginInComment(amplifiedTest, AmplificationHelper.getTopParent(test))
                 ).collect(Collectors.toList());
-    }
-
-    //empirically 200 seems to be enough
-    private static final int MAX_NUMBER_OF_TESTS = 200;
-
-    private List<CtMethod<?>> reduce(List<CtMethod<?>> newTests) {
-        if (newTests.size() > MAX_NUMBER_OF_TESTS) {
-            Log.warn("Too many tests has been generated: {}", newTests.size());
-            Collections.shuffle(newTests, AmplificationHelper.getRandom());
-            List<CtMethod<?>> reducedNewTests = newTests.subList(0, MAX_NUMBER_OF_TESTS);
-            Log.debug("Number of generated test reduced to {}", MAX_NUMBER_OF_TESTS);
-            return reducedNewTests;
-        } else {
-            return newTests;
-        }
     }
 
     private void resetAmplifiers(CtType parentClass) {

--- a/src/main/java/fr/inria/diversify/dspot/Amplification.java
+++ b/src/main/java/fr/inria/diversify/dspot/Amplification.java
@@ -147,7 +147,7 @@ public class Amplification {
                     String methodName = failure.getTestHeader();
                     CtMethod testToRemove = tests.stream()
                             .filter(m -> methodName.startsWith(m.getSimpleName()))
-                            .findAny().get();
+                            .findFirst().get();
                     tests.remove(tests.indexOf(testToRemove));
                     Log.warn("{}", testToRemove.getSimpleName());
                 } catch (Exception ignored) {

--- a/src/main/java/fr/inria/diversify/dspot/AmplificationHelper.java
+++ b/src/main/java/fr/inria/diversify/dspot/AmplificationHelper.java
@@ -6,6 +6,7 @@ import fr.inria.diversify.mutant.pit.PitRunner;
 import fr.inria.diversify.runner.InputConfiguration;
 import fr.inria.diversify.runner.InputProgram;
 import fr.inria.diversify.testRunner.JunitResult;
+import fr.inria.diversify.util.Log;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtMethod;
@@ -228,5 +229,20 @@ public class AmplificationHelper {
         classpath += ":" + inputProgram.getProgramDir() + "/" + inputProgram.getTestClassesDir();
         classpath += ":" + compiler.getDependencies();
         return classpath;
+    }
+
+    //empirically 200 seems to be enough
+    public static final int MAX_NUMBER_OF_TESTS = 200;
+
+    public static List<CtMethod<?>> reduce(List<CtMethod<?>> newTests) {
+        if (newTests.size() > MAX_NUMBER_OF_TESTS) {
+            Log.warn("Too many tests has been generated: {}", newTests.size());
+            Collections.shuffle(newTests, AmplificationHelper.getRandom());
+            List<CtMethod<?>> reducedNewTests = newTests.subList(0, MAX_NUMBER_OF_TESTS);
+            Log.debug("Number of generated test reduced to {}", MAX_NUMBER_OF_TESTS);
+            return reducedNewTests;
+        } else {
+            return newTests;
+        }
     }
 }

--- a/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertGenerator.java
+++ b/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertGenerator.java
@@ -1,6 +1,5 @@
 package fr.inria.diversify.dspot.assertGenerator;
 
-import fr.inria.diversify.dspot.AmplificationHelper;
 import fr.inria.diversify.dspot.support.DSpotCompiler;
 import fr.inria.diversify.runner.InputProgram;
 import fr.inria.diversify.util.Log;
@@ -35,13 +34,11 @@ public class AssertGenerator {
     public List<CtMethod<?>> generateAsserts(CtType testClass, Collection<CtMethod<?>> tests) throws IOException, ClassNotFoundException {
         CtType cloneClass = testClass.clone();
         cloneClass.setParent(testClass.getParent());
-        MethodsAssertGenerator ags = new MethodsAssertGenerator(testClass, inputProgram, compiler);
         final Map<CtMethod<?>, List<Integer>> statementIndexToAssert = tests.stream()
                 .collect(Collectors.toMap(Function.identity(), AssertGeneratorHelper::findStatementToAssert));
+        MethodsAssertGenerator ags = new MethodsAssertGenerator(testClass, inputProgram, compiler);
         final List<CtMethod<?>> amplifiedTestWithAssertion = ags.generateAsserts(testClass, new ArrayList<>(tests), statementIndexToAssert);
         Log.debug("{} new tests with assertions generated", amplifiedTestWithAssertion.size());
-        return amplifiedTestWithAssertion == null ? Collections.EMPTY_LIST : amplifiedTestWithAssertion;
+        return amplifiedTestWithAssertion;
     }
-
-
 }

--- a/src/main/java/fr/inria/diversify/dspot/assertGenerator/MethodAssertGenerator.java
+++ b/src/main/java/fr/inria/diversify/dspot/assertGenerator/MethodAssertGenerator.java
@@ -4,13 +4,13 @@ import fr.inria.diversify.compare.ObjectLog;
 import fr.inria.diversify.compare.Observation;
 import fr.inria.diversify.dspot.AmplificationHelper;
 import fr.inria.diversify.dspot.DSpotUtils;
+import fr.inria.diversify.dspot.selector.json.TestCaseJSON;
 import fr.inria.diversify.dspot.support.Counter;
 import fr.inria.diversify.dspot.support.DSpotCompiler;
 import fr.inria.diversify.runner.InputProgram;
 import fr.inria.diversify.testRunner.JunitResult;
 import fr.inria.diversify.testRunner.TestCompiler;
 import fr.inria.diversify.testRunner.TestRunner;
-import org.junit.runner.Request;
 import org.junit.runner.notification.Failure;
 import spoon.reflect.code.*;
 import spoon.reflect.declaration.CtMethod;
@@ -156,7 +156,7 @@ public class MethodAssertGenerator {
         }
         ObjectLog.reset();
         JunitResult result = runTests(cl, testsToRun);
-        if (result == null || !result.getFailures().isEmpty()) {// || result.getTestRuns().size() != testsToRun.size()) {
+        if (result == null || !result.getFailures().isEmpty()) {
             return null;
         }
         return buildTestWithAssert(ObjectLog.getObservations());
@@ -262,9 +262,10 @@ public class MethodAssertGenerator {
     }
 
     public JunitResult runTests(CtType testClass, List<CtMethod<?>> testsToRun) throws ClassNotFoundException {
-        boolean statusCompilation = TestCompiler.writeAndCompile(this.compiler, testClass, true,
-                inputProgram.getProgramDir() + "/" + inputProgram.getClassesDir() + ":" +
-                        inputProgram.getProgramDir() + "/" + inputProgram.getTestClassesDir());
+        final String dependencies = inputProgram.getProgramDir() + "/" + inputProgram.getClassesDir() + ":" +
+                inputProgram.getProgramDir() + "/" + inputProgram.getTestClassesDir();
+        boolean statusCompilation = TestCompiler.writeAndCompile(this.compiler, testClass,
+                true, dependencies);
         if (!statusCompilation) {
             return null;
         } else {

--- a/src/main/java/fr/inria/diversify/dspot/support/DSpotCompiler.java
+++ b/src/main/java/fr/inria/diversify/dspot/support/DSpotCompiler.java
@@ -86,10 +86,11 @@ public class DSpotCompiler extends JDTBasedSpoonCompiler {
         launcher.getEnvironment().setCommentEnabled(true);
         String[] sourcesArray = pathToSources.split(":");
         Arrays.stream(sourcesArray).forEach(launcher::addInputResource);
-        String[] dependenciesArray = pathToDependencies.split(":");
-        launcher.getModelBuilder().setSourceClasspath(dependenciesArray);
+        if (!pathToDependencies.isEmpty()) {
+            String[] dependenciesArray = pathToDependencies.split(":");
+            launcher.getModelBuilder().setSourceClasspath(dependenciesArray);
+        }
         launcher.buildModel();
-
         return launcher;
     }
 

--- a/src/main/java/fr/inria/diversify/dspot/support/DSpotCompiler.java
+++ b/src/main/java/fr/inria/diversify/dspot/support/DSpotCompiler.java
@@ -12,6 +12,7 @@ import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Created by Benjamin DANGLOT
@@ -71,8 +72,12 @@ public class DSpotCompiler extends JDTBasedSpoonCompiler {
         compiler.compile(finalArgs);
         environment = compiler.getEnvironment();
 
-
         return compiler.globalErrorsCount == 0;
+    }
+
+    public List<CategorizedProblem> compileAndGetProbs(String pathToAdditionalDependencies) {
+        this.compile(pathToAdditionalDependencies);
+        return getProblems();
     }
 
     public static Launcher getSpoonModelOf(String pathToSources, String pathToDependencies) {

--- a/src/main/java/fr/inria/diversify/dspot/value/ValueCreator.java
+++ b/src/main/java/fr/inria/diversify/dspot/value/ValueCreator.java
@@ -12,6 +12,8 @@ import spoon.reflect.reference.CtTypeReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static fr.inria.diversify.dspot.value.ValueType.factory;
+
 /**
  * User: Simon
  * Date: 07/01/16
@@ -31,7 +33,7 @@ public class ValueCreator {
         Factory factory = type.getFactory();
         CtExpression value = createValue(type);
         if (value != null) {
-            return factory.Code().createLocalVariable(type, "vc_" + count++, createValue(type));
+            return factory.Code().createLocalVariable(type, "vc_" + count++, value);
         } else {
             return null;
         }

--- a/src/main/java/fr/inria/diversify/testRunner/TestCompiler.java
+++ b/src/main/java/fr/inria/diversify/testRunner/TestCompiler.java
@@ -73,12 +73,12 @@ public class TestCompiler {
                                 }
                             },
                             HashSet<CtMethod<?>>::addAll);
-            final List<? extends CtMethod<?>> methods = methodsToRemove.stream()
+            final List<CtMethod<?>> methods = methodsToRemove.stream()
                     .map(CtMethod::getSimpleName)
                     .map(methodName -> (CtMethod<?>) classTest.getMethodsByName(methodName).get(0))
                     .collect(Collectors.toList());
             methods.forEach(classTest::removeMethod);
-            methodsToRemove.addAll(compile(compiler, classTest, withLogger, dependencies));
+            methods.addAll(compile(compiler, classTest, withLogger, dependencies));
             return new ArrayList<>(methods);
         }
     }

--- a/src/test/java/fr/inria/diversify/dspot/DSpotCompilerTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/DSpotCompilerTest.java
@@ -1,0 +1,113 @@
+package fr.inria.diversify.dspot;
+
+import fr.inria.diversify.dspot.amplifier.Amplifier;
+import fr.inria.diversify.dspot.support.DSpotCompiler;
+import fr.inria.diversify.runner.InputProgram;
+import fr.inria.diversify.testRunner.TestCompiler;
+import fr.inria.diversify.util.FileUtils;
+import org.junit.Test;
+import spoon.reflect.code.CtCodeSnippetStatement;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.factory.Factory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by Benjamin DANGLOT
+ * benjamin.danglot@inria.fr
+ * on 3/13/17
+ */
+public class DSpotCompilerTest {
+
+    @Test
+    public void testDSpotCompiler() throws Exception {
+
+        final InputProgram inputProgram = getInputProgram();
+        final DSpotCompiler compiler = new DSpotCompiler(inputProgram, "");
+        final CtClass<?> aClass = getClass(compiler.getLauncher().getFactory());
+        final List<CtMethod<?>> compile = TestCompiler.compile(compiler, aClass, false, "");
+        assertTrue(compile.isEmpty());
+        assertEquals(1, aClass.getMethods().size());
+
+        final List<CtMethod> tests = new UncompilableAmplifier().apply(aClass.getMethods().stream().findAny().get());
+        tests.forEach(aClass::addMethod);
+        assertEquals(3, aClass.getMethods().size());
+
+        final CtMethod uncompilableTest = tests.stream()
+                .filter(ctMethod -> ctMethod.getSimpleName().equals("uncompilableTest"))
+                .findFirst()
+                .get();
+
+        final List<CtMethod<?>> results = TestCompiler.compile(compiler, aClass, false, "");
+        assertEquals(1, results.size());
+        assertEquals("uncompilableTest", results.get(0).getSimpleName());
+        assertEquals(uncompilableTest, results.get(0));
+        assertEquals(2, aClass.getMethods().size());
+    }
+
+    // quick implementation used to produce a uncompilable test case
+    private class UncompilableAmplifier implements Amplifier {
+
+        @Override
+        public List<CtMethod> apply(CtMethod testMethod) {
+            final CtCodeSnippetStatement snippet = testMethod.getFactory().Code().
+                    createCodeSnippetStatement("UncompilableClass class = new UncompilableClass()");
+            final CtMethod method = testMethod.clone();
+            method.getBody().insertEnd(snippet);
+            method.setSimpleName("uncompilableTest");
+
+            final CtCodeSnippetStatement snippet1 = testMethod.getFactory().Code().createCodeSnippetStatement("String clazz = new String()");
+            final CtMethod method1 = testMethod.clone();
+            method1.getBody().insertEnd(snippet1);
+            method1.setSimpleName("compilableTest");
+
+            return Arrays.asList(method, method1);
+        }
+
+        @Override
+        public CtMethod applyRandom(CtMethod testMethod) {
+            return null;
+        }
+
+        @Override
+        public void reset(CtType testClass) {
+
+        }
+
+    }
+    private InputProgram getInputProgram() {
+        final File tmpDir = new File("tmpDir");
+        if (tmpDir.exists()) {
+            try {
+                FileUtils.cleanDirectory(tmpDir);
+            } catch (IOException ignored) {
+                //ignored
+            }
+        }
+        final InputProgram inputProgram = new InputProgram();
+        inputProgram.setProgramDir("tmpDir/tmp");
+        inputProgram.setRelativeSourceCodeDir("src/main/java/");
+        inputProgram.setRelativeTestSourceCodeDir("src/test/java");
+        return inputProgram;
+    }
+
+    private CtClass<?> getClass(Factory factory) {
+        final CtClass<?> aClass = factory.Class().create("MyTestClass");
+        final CtMethod<Void> method = factory.createMethod();
+        method.setSimpleName("method");
+        method.setType(factory.Type().VOID_PRIMITIVE);
+        method.setBody(factory.createCodeSnippetStatement("System.out.println()"));
+        method.addModifier(ModifierKind.PUBLIC);
+        aClass.addMethod(method);
+        return aClass;
+    }
+}

--- a/src/test/java/fr/inria/diversify/dspot/DSpotTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/DSpotTest.java
@@ -38,9 +38,9 @@ public class DSpotTest extends MavenAbstractTest {
     private final String expectedAmplifiedBody = "{" + nl +
             "    example.Example ex = new example.Example();" + nl + 
             "    // StatementAdderOnAssert create random local variable" + nl + 
-            "    int vc_4 = 1635508580;" + nl + 
+            "    int vc_4 = -619987209;" + nl +
             "    // AssertGenerator add assertion" + nl + 
-            "    org.junit.Assert.assertEquals(vc_4, 1635508580);" + nl + 
+            "    org.junit.Assert.assertEquals(vc_4, -619987209);" + nl +
             "    // StatementAdderOnAssert create literal from method" + nl + 
             "    java.lang.String String_vc_0 = \"abcd\";" + nl + 
             "    // AssertGenerator add assertion" + nl + 
@@ -51,7 +51,7 @@ public class DSpotTest extends MavenAbstractTest {
             "    char o_test2_cf16__9 = // StatementAdderMethod cloned existing statement" + nl + 
             "vc_1.charAt(String_vc_0, vc_4);" + nl + 
             "    // AssertGenerator add assertion" + nl + 
-            "    org.junit.Assert.assertEquals(o_test2_cf16__9, 'd');" + nl + 
+            "    org.junit.Assert.assertEquals(o_test2_cf16__9, 'a');" + nl +
             "    org.junit.Assert.assertEquals('d', ex.charAt(\"abcd\", 3));" + nl + 
             "}";
 

--- a/src/test/java/fr/inria/diversify/dspot/amplifier/TestStatementAdderOnAssert.java
+++ b/src/test/java/fr/inria/diversify/dspot/amplifier/TestStatementAdderOnAssert.java
@@ -67,7 +67,7 @@ public class TestStatementAdderOnAssert extends AbstractTest {
         assertEquals("// StatementAdderMethod cloned existing statement\nvc_0.minusOne(int_vc_0)", currentMethod.getBody().getStatement(3).toString());
 
         currentMethod = amplifiedMethods.get(1);
-        assertEquals("825130495", ((CtLocalVariable)(currentMethod.getBody().getStatement(1))).getDefaultExpression().toString());
+        assertEquals("156591366", ((CtLocalVariable)(currentMethod.getBody().getStatement(1))).getDefaultExpression().toString());
         assertTrue(currentMethod.getBody().getStatement(3) instanceof  CtInvocation);
         assertEquals("// StatementAdderMethod cloned existing statement\nvc_0.minusOne(vc_2)", currentMethod.getBody().getStatement(3).toString());
 

--- a/src/test/java/fr/inria/diversify/dspot/amplifier/TestValueCreator.java
+++ b/src/test/java/fr/inria/diversify/dspot/amplifier/TestValueCreator.java
@@ -39,7 +39,7 @@ public class TestValueCreator extends AbstractTest {
 
         assertEquals("vc_"+count, randomLocalVar.getSimpleName());
         assertEquals(factory.Type().INTEGER_PRIMITIVE, randomLocalVar.getType());
-        assertEquals(1434614297, ((CtLiteral)randomLocalVar.getDefaultExpression()).getValue());
+        assertEquals(-1150482841, ((CtLiteral)randomLocalVar.getDefaultExpression()).getValue());
 
         randomLocalVar = valueCreator.createRandomLocalVar(factory.Type().createArrayReference("int"));
         count++;

--- a/src/test/java/fr/inria/diversify/mutant/pit/PitTest.java
+++ b/src/test/java/fr/inria/diversify/mutant/pit/PitTest.java
@@ -3,15 +3,9 @@ package fr.inria.diversify.mutant.pit;
 import fr.inria.diversify.Utils;
 import fr.inria.diversify.buildSystem.android.InvalidSdkException;
 import fr.inria.diversify.dspot.*;
-import fr.inria.diversify.dspot.support.DSpotCompiler;
-import fr.inria.diversify.runner.InputConfiguration;
-import fr.inria.diversify.runner.InputProgram;
-import fr.inria.diversify.util.FileUtils;
-import fr.inria.diversify.util.InitUtils;
 import org.junit.Test;
 import spoon.reflect.declaration.CtClass;
 
-import java.io.File;
 import java.util.*;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/resources/sample/src/test/java/fr/inria/compiler/TestCompiler.java
+++ b/src/test/resources/sample/src/test/java/fr/inria/compiler/TestCompiler.java
@@ -1,0 +1,16 @@
+package fr.inria.compiler;
+
+import org.junit.Test;
+
+/**
+ * Created by Benjamin DANGLOT
+ * benjamin.danglot@inria.fr
+ * on 3/13/17
+ */
+public class TestCompiler {
+
+    @Test
+    public void test() throws Exception {
+        
+    }
+}


### PR DESCRIPTION
Hello, 

The PR #78 introduced a bug: when a test case was uncompilable, dspot skipped the whole iteration.

Now, we discard test cases that produce compilation error and recompile after that.