### PR TITLE
Gradle projects support - prerequisites

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,11 @@
                 <updatePolicy>always</updatePolicy>
             </snapshots>
         </repository>
+        <repository>
+            <id>gradle-repo</id>
+            <name>Gradle Tooling API repository</name>
+            <url>https://repo.gradle.org/gradle/libs-releases-local/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -65,6 +70,12 @@
             <groupId>fr.inria.stamp</groupId>
             <artifactId>descartes</artifactId>
             <version>0.1-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-tooling-api</artifactId>
+            <version>4.0.1</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/fr/inria/diversify/automaticbuilder/AutomaticBuilderFactory.java
+++ b/src/main/java/fr/inria/diversify/automaticbuilder/AutomaticBuilderFactory.java
@@ -1,0 +1,29 @@
+package fr.inria.diversify.automaticbuilder;
+
+import fr.inria.diversify.runner.InputConfiguration;
+import fr.inria.diversify.util.Log;
+
+/**
+ * Created by Daniele Gagliardi
+ * daniele.gagliardi@eng.it
+ * on 14/07/17.
+ */
+public class AutomaticBuilderFactory {
+
+    public AutomaticBuilder getAutomaticBuilder(InputConfiguration configuration) {
+        String builderType = configuration.getProperty("automaticBuilderName");
+        if (builderType == null) {
+            Log.warn("No automatic builder specified in configuration, going to default.");
+            Log.debug("Default: provided Maven automatic builder.");
+            return new MavenAutomaticBuilder(configuration);
+        }
+        if (builderType.toUpperCase().contains("MAVEN")) {
+            Log.debug("Selected Maven automatic builder.");
+            return new MavenAutomaticBuilder(configuration);
+        }
+        Log.warn(builderType + ": unknown automatic builder specified in configuration, going to default.");
+        Log.debug("Default: provided Maven automatic builder.");
+        return new MavenAutomaticBuilder(configuration);
+    }
+
+}

--- a/src/main/java/fr/inria/diversify/automaticbuilder/AutomaticBuilderFactory.java
+++ b/src/main/java/fr/inria/diversify/automaticbuilder/AutomaticBuilderFactory.java
@@ -17,6 +17,10 @@ public class AutomaticBuilderFactory {
             Log.debug("Default: provided Maven automatic builder.");
             return new MavenAutomaticBuilder(configuration);
         }
+        if (builderType.toUpperCase().contains("GRADLE")) {
+            Log.debug("Selected Gradle automatic builder.");
+            return new GradleAutomaticBuilder();
+        }
         if (builderType.toUpperCase().contains("MAVEN")) {
             Log.debug("Selected Maven automatic builder.");
             return new MavenAutomaticBuilder(configuration);

--- a/src/main/java/fr/inria/diversify/automaticbuilder/GradleAutomaticBuilder.java
+++ b/src/main/java/fr/inria/diversify/automaticbuilder/GradleAutomaticBuilder.java
@@ -1,0 +1,38 @@
+package fr.inria.diversify.automaticbuilder;
+
+import fr.inria.diversify.mutant.pit.PitResult;
+import spoon.reflect.declaration.CtType;
+
+import java.util.List;
+
+/**
+ * Created by Daniele Gagliardi
+ * daniele.gagliardi@eng.it
+ * on 18/07/17.
+ */
+public class GradleAutomaticBuilder implements AutomaticBuilder {
+
+    @Override
+    public void compile(String pathToRootOfProject) {
+
+    }
+
+    @Override
+    public String buildClasspath(String pathToRootOfProject) {
+        return null;
+    }
+
+    @Override
+    public List<PitResult> runPit(String pathToRootOfProject, CtType<?> testClass) {
+        return null;
+    }
+
+    @Override
+    public List<PitResult> runPit(String pathToRootOfProject) {
+        return null;
+    }
+
+    protected void runTasks() {
+
+    }
+}

--- a/src/main/java/fr/inria/diversify/dspot/DSpot.java
+++ b/src/main/java/fr/inria/diversify/dspot/DSpot.java
@@ -3,7 +3,7 @@ package fr.inria.diversify.dspot;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import fr.inria.diversify.automaticbuilder.AutomaticBuilder;
-import fr.inria.diversify.automaticbuilder.MavenAutomaticBuilder;
+import fr.inria.diversify.automaticbuilder.AutomaticBuilderFactory;
 import fr.inria.diversify.buildSystem.android.InvalidSdkException;
 import fr.inria.diversify.dspot.amplifier.*;
 import fr.inria.diversify.dspot.selector.BranchCoverageTestSelector;
@@ -88,6 +88,7 @@ public class DSpot {
     }
 
     public DSpot(InputConfiguration inputConfiguration, int numberOfIterations, List<Amplifier> amplifiers, TestSelector testSelector) throws InvalidSdkException, Exception {
+        AutomaticBuilderFactory builderFactory = new AutomaticBuilderFactory();
         this.testResources = new ArrayList<>();
         this.inputConfiguration = inputConfiguration;
         InitUtils.initLogLevel(inputConfiguration);
@@ -117,11 +118,12 @@ public class DSpot {
             DescartesInjector.injectDescartesIntoPom(inputProgram.getProgramDir() + "/pom.xml");
         }
 
-        this.builder = new MavenAutomaticBuilder(inputConfiguration);//TODO
+        this.builder = builderFactory.getAutomaticBuilder(inputConfiguration);
+
         String dependencies = this.builder.buildClasspath(this.inputProgram.getProgramDir());
         File output = new File(inputProgram.getProgramDir() + "/" + inputProgram.getClassesDir());
         boolean status = DSpotCompiler.compile(inputProgram.getAbsoluteSourceCodeDir()
-                + System.getProperty("path.separator") + inputProgram.getAbsoluteTestSourceCodeDir(),
+                        + System.getProperty("path.separator") + inputProgram.getAbsoluteTestSourceCodeDir(),
                 dependencies,
                 output);
         if (!status) {
@@ -135,7 +137,7 @@ public class DSpot {
             DSpotUtils.copyLoggerPackage(inputProgram);
             FileUtils.cleanDirectory(output);
             status = DSpotCompiler.compile(inputProgram.getAbsoluteSourceCodeDir()
-                    + System.getProperty("path.separator") + inputProgram.getAbsoluteTestSourceCodeDir(),
+                            + System.getProperty("path.separator") + inputProgram.getAbsoluteTestSourceCodeDir(),
                     dependencies, output);
             if (!status) {
                 throw new RuntimeException("Error during compilation");

--- a/src/main/java/fr/inria/diversify/dspot/selector/PitMutantScoreSelector.java
+++ b/src/main/java/fr/inria/diversify/dspot/selector/PitMutantScoreSelector.java
@@ -3,7 +3,7 @@ package fr.inria.diversify.dspot.selector;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import fr.inria.diversify.automaticbuilder.AutomaticBuilder;
-import fr.inria.diversify.automaticbuilder.MavenAutomaticBuilder;
+import fr.inria.diversify.automaticbuilder.AutomaticBuilderFactory;
 import fr.inria.diversify.dspot.AmplificationChecker;
 import fr.inria.diversify.dspot.AmplificationHelper;
 import fr.inria.diversify.dspot.selector.json.MutantJSON;
@@ -57,9 +57,11 @@ public class PitMutantScoreSelector implements TestSelector {
 
     @Override
     public void init(InputConfiguration configuration) {
+        AutomaticBuilderFactory builderFactory = new AutomaticBuilderFactory();
+
         this.configuration = configuration;
         this.program = this.configuration.getInputProgram();
-        this.builder = new MavenAutomaticBuilder(this.configuration);// TODO
+        this.builder = builderFactory.getAutomaticBuilder(configuration);
         if (this.originalKilledMutants == null) {
             initOriginalPitResult(this.builder.runPit(this.program.getProgramDir()));
         }

--- a/src/main/java/fr/inria/stamp/Configuration.java
+++ b/src/main/java/fr/inria/stamp/Configuration.java
@@ -16,9 +16,10 @@ public class Configuration {
     public final List<String> namesOfTestCases;
     public final long seed;
     public final int timeOutInMs;
+    public final String automaticBuilderName;
     public final String mavenHome;
 
-    public Configuration(String pathToConfigurationFile, List<Amplifier> amplifiers, int nbIteration, List<String> testClasses, String pathToOutput, TestSelector selector, List<String> namesOfTestCases, long seed, int timeOutInMs, String mavenHome) {
+    public Configuration(String pathToConfigurationFile, List<Amplifier> amplifiers, int nbIteration, List<String> testClasses, String pathToOutput, TestSelector selector, List<String> namesOfTestCases, long seed, int timeOutInMs, String automaticBuilderName, String mavenHome) {
         this.pathToConfigurationFile = pathToConfigurationFile;
         this.amplifiers = amplifiers;
         this.nbIteration = nbIteration;
@@ -28,6 +29,7 @@ public class Configuration {
         this.namesOfTestCases = namesOfTestCases;
         this.seed = seed;
         this.timeOutInMs = timeOutInMs;
+        this.automaticBuilderName = automaticBuilderName;
         this.mavenHome = mavenHome;
     }
 }

--- a/src/main/java/fr/inria/stamp/JSAPOptions.java
+++ b/src/main/java/fr/inria/stamp/JSAPOptions.java
@@ -84,6 +84,7 @@ public class JSAPOptions {
                 Arrays.asList(jsapConfig.getStringArray("testClasses")),
                 jsapConfig.getLong("seed"),
                 jsapConfig.getInt("timeOut"),
+                jsapConfig.getString("builder"),
                 jsapConfig.getString("mavenHome"));
     }
 
@@ -207,6 +208,14 @@ public class JSAPOptions {
         timeOut.setHelp("specify the timeout value of the degenerated tests in millisecond");
         timeOut.setDefault("10000");
 
+        FlaggedOption automaticBuilder = new FlaggedOption("builder");
+        automaticBuilder.setStringParser(JSAP.STRING_PARSER);
+        automaticBuilder.setLongFlag("automatic-builder");
+        automaticBuilder.setShortFlag('b');
+        automaticBuilder.setUsageName("MavenBuilder | GradleBuilder");
+        automaticBuilder.setHelp("[optional] specify the automatic builder to build the project");
+        automaticBuilder.setDefault("MavenBuilder");
+
         FlaggedOption mavenHome = new FlaggedOption("mavenHome");
         mavenHome.setStringParser(JSAP.STRING_PARSER);
         mavenHome.setLongFlag("maven-home");
@@ -233,6 +242,7 @@ public class JSAPOptions {
             jsap.registerParameter(testCases);
             jsap.registerParameter(output);
             jsap.registerParameter(mutantScore);
+            jsap.registerParameter(automaticBuilder);
             jsap.registerParameter(mavenHome);
             jsap.registerParameter(seed);
             jsap.registerParameter(timeOut);

--- a/src/main/java/fr/inria/stamp/Main.java
+++ b/src/main/java/fr/inria/stamp/Main.java
@@ -27,6 +27,7 @@ public class Main {
         AmplificationHelper.setSeedRandom(23L);
         InputProgram program = new InputProgram();
         inputConfiguration.setInputProgram(program);
+        inputConfiguration.getProperties().setProperty("automaticBuilderName", configuration.automaticBuilderName);
         if (configuration.mavenHome != null) {
             inputConfiguration.getProperties().put("maven.home", configuration.mavenHome);
         }

--- a/src/test/java/fr/inria/diversify/automaticbuilder/AutomaticBuilderFactoryTest.java
+++ b/src/test/java/fr/inria/diversify/automaticbuilder/AutomaticBuilderFactoryTest.java
@@ -1,0 +1,152 @@
+package fr.inria.diversify.automaticbuilder;
+
+import fr.inria.diversify.dspot.DSpotUtils;
+import fr.inria.diversify.runner.InputConfiguration;
+import fr.inria.stamp.Configuration;
+import fr.inria.stamp.JSAPOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by Daniele Gagliardi
+ * daniele.gagliardi@eng.it
+ * on 14/07/17.
+ */
+public class AutomaticBuilderFactoryTest {
+
+    private static final String PATH_SEPARATOR = System.getProperty("path.separator");
+
+    private Configuration configuration;
+
+    private AutomaticBuilderFactory sut;
+
+    @Before
+    public void setUp() throws Exception {
+        sut = new AutomaticBuilderFactory();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void getAutomaticBuilder_whenMaven() throws Exception {
+
+        this.configuration = JSAPOptions.parse(getArgsWithMavenBuilder());
+
+        InputConfiguration inputConfiguration = new InputConfiguration(configuration.pathToConfigurationFile);
+        inputConfiguration.getProperties().setProperty("automaticBuilderName", configuration.automaticBuilderName);
+
+        assertTrue(inputConfiguration.getProperty("automaticBuilderName").toUpperCase().contains("MAVEN"));
+
+        AutomaticBuilder builder = this.sut.getAutomaticBuilder(inputConfiguration);
+
+        assertNotNull(builder);
+        assertTrue(builder.getClass().equals(MavenAutomaticBuilder.class));
+    }
+
+    @Test
+    public void getAutomaticBuilder_whenGradle() throws Exception {
+
+        this.configuration = JSAPOptions.parse(getArgsWithGradleBuilder());
+
+        InputConfiguration inputConfiguration = new InputConfiguration(configuration.pathToConfigurationFile);
+        inputConfiguration.getProperties().setProperty("automaticBuilderName", configuration.automaticBuilderName);
+
+        assertTrue(inputConfiguration.getProperty("automaticBuilderName").toUpperCase().contains("GRADLE"));
+
+        AutomaticBuilder builder = this.sut.getAutomaticBuilder(inputConfiguration);
+
+        assertNotNull(builder);
+        assertTrue(builder.getClass().equals(MavenAutomaticBuilder.class));
+    }
+
+    @Test
+    public void getAutomaticBuilder_whenUnknown() throws Exception {
+
+        this.configuration = JSAPOptions.parse(getArgsWithGradleBuilder());
+
+        InputConfiguration inputConfiguration = new InputConfiguration(configuration.pathToConfigurationFile);
+        inputConfiguration.getProperties().setProperty("automaticBuilderName", configuration.automaticBuilderName);
+
+        assertFalse(inputConfiguration.getProperty("automaticBuilderName") == null);
+        assertFalse(inputConfiguration.getProperty("automaticBuilderName").toUpperCase().contains("MAVEN"));
+        assertFalse(!inputConfiguration.getProperty("automaticBuilderName").toUpperCase().contains("GRADLE"));
+
+        AutomaticBuilder builder = this.sut.getAutomaticBuilder(inputConfiguration);
+
+        assertNotNull(builder);
+        assertTrue(builder.getClass().equals(MavenAutomaticBuilder.class));
+    }
+
+    @Test
+    public void getAutomaticBuilder_whenConfDoesntContainBuilder() throws Exception {
+
+        this.configuration = JSAPOptions.parse(getArgsWithNoBuilder());
+
+        InputConfiguration inputConfiguration = new InputConfiguration(configuration.pathToConfigurationFile);
+
+        assertTrue(inputConfiguration.getProperty("automaticBuilderName") == null);
+
+        AutomaticBuilder builder = this.sut.getAutomaticBuilder(inputConfiguration);
+
+        assertNotNull(builder);
+        assertTrue(builder.getClass().equals(MavenAutomaticBuilder.class));
+    }
+
+    private String[] getArgsWithMavenBuilder() throws IOException {
+        return new String[]{
+                "--path-to-properties", "src/test/resources/test-projects/test-projects.properties",
+                "--test-criterion", "BranchCoverageTestSelector",
+                "--amplifiers", "MethodAdd" + PATH_SEPARATOR + "TestDataMutator" + PATH_SEPARATOR + "StatementAdderOnAssert",
+                "--iteration", "1",
+                "--randomSeed", "72",
+                "--maven-home", DSpotUtils.buildMavenHome(new InputConfiguration("src/test/resources/test-projects/test-projects.properties")),
+                "--automatic-builder", "MavenBuilder",
+                "--test", "all"
+        };
+    }
+
+    private String[] getArgsWithGradleBuilder() throws IOException {
+        return new String[]{
+                "--path-to-properties", "src/test/resources/test-projects/test-projects.properties",
+                "--test-criterion", "BranchCoverageTestSelector",
+                "--amplifiers", "MethodAdd" + PATH_SEPARATOR + "TestDataMutator" + PATH_SEPARATOR + "StatementAdderOnAssert",
+                "--iteration", "1",
+                "--randomSeed", "72",
+                "--maven-home", DSpotUtils.buildMavenHome(new InputConfiguration("src/test/resources/test-projects/test-projects.properties")),
+                "--automatic-builder", "GradleBuilder",
+                "--test", "all"
+        };
+    }
+
+    private String[] getArgsWithUnknownBuilder() throws IOException {
+        return new String[]{
+                "--path-to-properties", "src/test/resources/test-projects/test-projects.properties",
+                "--test-criterion", "BranchCoverageTestSelector",
+                "--amplifiers", "MethodAdd" + PATH_SEPARATOR + "TestDataMutator" + PATH_SEPARATOR + "StatementAdderOnAssert",
+                "--iteration", "1",
+                "--randomSeed", "72",
+                "--maven-home", DSpotUtils.buildMavenHome(new InputConfiguration("src/test/resources/test-projects/test-projects.properties")),
+                "--automatic-builder", "UNKNOWNBuilder",
+                "--test", "all"
+        };
+    }
+
+    private String[] getArgsWithNoBuilder() throws IOException {
+        return new String[]{
+                "--path-to-properties", "src/test/resources/test-projects/test-projects.properties",
+                "--test-criterion", "BranchCoverageTestSelector",
+                "--amplifiers", "MethodAdd" + PATH_SEPARATOR + "TestDataMutator" + PATH_SEPARATOR + "StatementAdderOnAssert",
+                "--iteration", "1",
+                "--randomSeed", "72",
+                "--maven-home", DSpotUtils.buildMavenHome(new InputConfiguration("src/test/resources/test-projects/test-projects.properties")),
+                "--test", "all"
+        };
+    }
+}

--- a/src/test/java/fr/inria/diversify/automaticbuilder/AutomaticBuilderFactoryTest.java
+++ b/src/test/java/fr/inria/diversify/automaticbuilder/AutomaticBuilderFactoryTest.java
@@ -63,20 +63,20 @@ public class AutomaticBuilderFactoryTest {
         AutomaticBuilder builder = this.sut.getAutomaticBuilder(inputConfiguration);
 
         assertNotNull(builder);
-        assertTrue(builder.getClass().equals(MavenAutomaticBuilder.class));
+        assertTrue(builder.getClass().equals(GradleAutomaticBuilder.class));
     }
 
     @Test
     public void getAutomaticBuilder_whenUnknown() throws Exception {
 
-        this.configuration = JSAPOptions.parse(getArgsWithGradleBuilder());
+        this.configuration = JSAPOptions.parse(getArgsWithUnknownBuilder());
 
         InputConfiguration inputConfiguration = new InputConfiguration(configuration.pathToConfigurationFile);
         inputConfiguration.getProperties().setProperty("automaticBuilderName", configuration.automaticBuilderName);
 
         assertFalse(inputConfiguration.getProperty("automaticBuilderName") == null);
         assertFalse(inputConfiguration.getProperty("automaticBuilderName").toUpperCase().contains("MAVEN"));
-        assertFalse(!inputConfiguration.getProperty("automaticBuilderName").toUpperCase().contains("GRADLE"));
+        assertFalse(inputConfiguration.getProperty("automaticBuilderName").toUpperCase().contains("GRADLE"));
 
         AutomaticBuilder builder = this.sut.getAutomaticBuilder(inputConfiguration);
 

--- a/src/test/java/fr/inria/diversify/automaticbuilder/GradleAutomaticBuilderTest.java
+++ b/src/test/java/fr/inria/diversify/automaticbuilder/GradleAutomaticBuilderTest.java
@@ -1,0 +1,72 @@
+package fr.inria.diversify.automaticbuilder;
+
+import fr.inria.diversify.dspot.DSpotUtils;
+import fr.inria.diversify.runner.InputConfiguration;
+import fr.inria.stamp.Configuration;
+import fr.inria.stamp.JSAPOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by Daniele Gagliardi
+ * daniele.gagliardi@eng.it
+ * on 18/07/17.
+ */
+public class GradleAutomaticBuilderTest {
+
+    private static final String PATH_SEPARATOR = System.getProperty("path.separator");
+
+    private Configuration configuration;
+
+    AutomaticBuilderFactory factory = new AutomaticBuilderFactory();
+
+    AutomaticBuilder sut = null;
+
+    @Before
+    public void setUp() throws Exception {
+        this.configuration = JSAPOptions.parse(getArgsWithGradleBuilder());
+        InputConfiguration inputConfiguration = new InputConfiguration(configuration.pathToConfigurationFile);
+        inputConfiguration.getProperties().setProperty("automaticBuilderName", configuration.automaticBuilderName);
+
+        sut = factory.getAutomaticBuilder(inputConfiguration);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void compile() throws Exception {
+    }
+
+    @Test
+    public void buildClasspath() throws Exception {
+    }
+
+    @Test
+    public void runPit() throws Exception {
+    }
+
+    @Test
+    public void runPit1() throws Exception {
+    }
+
+    private String[] getArgsWithGradleBuilder() throws IOException {
+        return new String[]{
+                "--path-to-properties", "src/test/resources/test-gradle-projects/test-projects.properties",
+                "--test-criterion", "BranchCoverageTestSelector",
+                "--amplifiers", "MethodAdd" + PATH_SEPARATOR + "TestDataMutator" + PATH_SEPARATOR + "StatementAdderOnAssert",
+                "--iteration", "1",
+                "--randomSeed", "72",
+//                "--maven-home", DSpotUtils.buildMavenHome(new InputConfiguration("src/test/resources/test-gradle-projects/test-projects.properties")),
+                "--automatic-builder", "GradleBuilder",
+                "--test", "all"
+        };
+    }
+
+}

--- a/src/test/java/fr/inria/diversify/mutant/pit/PitTest.java
+++ b/src/test/java/fr/inria/diversify/mutant/pit/PitTest.java
@@ -8,7 +8,6 @@ import fr.inria.diversify.dspot.*;
 import org.junit.Test;
 import spoon.reflect.declaration.CtClass;
 
-import javax.rmi.CORBA.Util;
 import java.util.*;
 
 import static org.junit.Assert.*;
@@ -36,7 +35,7 @@ public class PitTest extends MavenAbstractTest {
 
         Utils.init(this.getPathToPropertiesFile());
         CtClass<Object> testClass = Utils.getInputProgram().getFactory().Class().get("example.TestSuiteExample");
-        AutomaticBuilder builder = new MavenAutomaticBuilder(Utils.getInputConfiguration());
+        AutomaticBuilder builder = new MavenAutomaticBuilder(Utils.getInputConfiguration()); //TODO should we use the builder factory?
 
         List<PitResult> pitResults = builder.runPit(Utils.getInputProgram().getProgramDir(), testClass);
 

--- a/src/test/resources/test-gradle-projects/build.gradle
+++ b/src/test/resources/test-gradle-projects/build.gradle
@@ -1,0 +1,18 @@
+description = """
+Test Gradle project for DSpot test cases
+
+Project name: dspot.gradle.java.example
+
+"""
+apply plugin: 'java'
+
+version = "0.0.1"
+sourceCompatibility = 1.7
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testCompile 'junit:junit:4.12'
+}

--- a/src/test/resources/test-gradle-projects/src/main/java/example/Example.java
+++ b/src/test/resources/test-gradle-projects/src/main/java/example/Example.java
@@ -1,0 +1,29 @@
+package example;
+
+public class Example {
+
+	/*
+	 * Return the index char of s 
+	 * or the last if index > s.length
+	 * or the first if index < 0			
+	 */
+	public char charAt(String s, int index){
+		
+		if ( index <= 0 )
+			return s.charAt(0);
+		
+		if ( index < s.length() )
+			return s.charAt(index);
+		
+		return s.charAt(s.length()-1);
+	}
+	
+	public Example() {
+		int variableInsideConstructor;
+		variableInsideConstructor = 15; 
+		index = 2 * variableInsideConstructor;
+	}
+	
+	private int index = 419382;
+	private static String s = "Overloading field name with parameter name";
+}

--- a/src/test/resources/test-gradle-projects/src/test/java/example/TestSuiteExample.java
+++ b/src/test/resources/test-gradle-projects/src/test/java/example/TestSuiteExample.java
@@ -1,0 +1,46 @@
+
+
+package example;
+
+
+public class TestSuiteExample {
+
+    @org.junit.Test
+    public void test2() {
+        example.Example ex = new example.Example();
+        org.junit.Assert.assertEquals('d', ex.charAt("abcd", 3));
+    }
+
+    @org.junit.Test
+    public void test3() {
+        example.Example ex = new example.Example();
+        java.lang.String s = "abcd";
+        org.junit.Assert.assertEquals('d', ex.charAt(s, ((s.length()) - 1)));
+    }
+
+    @org.junit.Test
+    public void test4() {
+        example.Example ex = new example.Example();
+        java.lang.String s = "abcd";
+        org.junit.Assert.assertEquals('d', ex.charAt(s, 12));
+    }
+
+    @org.junit.Test
+    public void test7() {
+        example.Example ex = new example.Example();
+        org.junit.Assert.assertEquals('c', ex.charAt("abcd", 2));
+    }
+
+    @org.junit.Test
+    public void test8() {
+        example.Example ex = new example.Example();
+        org.junit.Assert.assertEquals('b', ex.charAt("abcd", 1));
+    }
+
+    @org.junit.Test
+    public void test9() {
+        example.Example ex = new example.Example();
+        org.junit.Assert.assertEquals('f', ex.charAt("abcdefghijklm", 5));
+    }
+}
+

--- a/src/test/resources/test-gradle-projects/test-projects.properties
+++ b/src/test/resources/test-gradle-projects/test-projects.properties
@@ -1,0 +1,12 @@
+#relative path to the project root from dspot project
+project=src/test/resources/test-gradle-projects
+#relative path to the source project from the project properties
+src=src/main/java/
+#relative path to the test source project from the project properties
+testSrc=src/test/java
+#java version used
+javaVersion=8
+#filter used to amplify specific test cases
+filter=example.*
+#path to the output folder
+outputDirectory=dspot-out/


### PR DESCRIPTION
Bonjour @danglotb, I added a Gradle test project to be used to verify Gradle Automatic Builder implementation. You will find an early empty implementation, and a change in the DSPot POM: I added Gradle Tooling API dependencies (a new repository and the needed dependency) in order to develop the gradle automatic builder implementation. I've also refactored some related test case. All DSpot tests passed.