### PR TITLE
Regression selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ src/test/resources/aResourcesDirectory/
 src/test/resources/test-projects/.gradle/
 src/test/resources/test-projects/gjp_cp
 src/test/resources/test-projects/cp
+src/test/resources/regression/test-projects_1/cp
+*.properties
 
 target/
 pom.xml.tag

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ src/test/resources/test-projects/.gradle/
 src/test/resources/test-projects/gjp_cp
 src/test/resources/test-projects/cp
 src/test/resources/regression/test-projects_1/cp
-*.properties
+src/test/resources/test-projects/test-projects.properties
+src/test/resources/test-projects/sample.properties
 
 target/
 pom.xml.tag

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,9 @@
                 <configuration>
                     <filesets>
                         <fileset>
+                            <directory>tmpDir/</directory>
+                        </fileset>
+                        <fileset>
                             <directory>src/test/resources/</directory>
                             <includes>
                                 <include>descartes/target/</include>

--- a/src/main/java/fr/inria/diversify/dspot/amplifier/StatementAdd.java
+++ b/src/main/java/fr/inria/diversify/dspot/amplifier/StatementAdd.java
@@ -44,11 +44,12 @@ public class StatementAdd implements Amplifier {
 		final List<CtMethod<?>> generateNewObjects = generateNewObjects(method);
 
 		// reuse existing object in test to add call to methods
-		final List<CtMethod> useExistingObject = useExistingObject(method); // original
-		useExistingObject.addAll(generateNewObjects.stream() // + generated at previous step
+		List<CtMethod> useExistingObject = useExistingObject(method); // original
+		useExistingObject.addAll(generateNewObjects);
+		useExistingObject = useExistingObject.stream() // + generated at previous step
 				.flatMap(ctMethod -> useExistingObject(ctMethod).stream())
-				.collect(Collectors.toList())
-		);
+				.collect(Collectors.toList());
+
 		// use results of existing method call to generate new statement.
 		final List<CtMethod> useReturnValuesOfExistingMethodCall = useReturnValuesOfExistingMethodCall(method);  // original
 		useReturnValuesOfExistingMethodCall.addAll(generateNewObjects.stream() // + generated at previous step

--- a/src/main/java/fr/inria/diversify/dspot/amplifier/StatementAdd.java
+++ b/src/main/java/fr/inria/diversify/dspot/amplifier/StatementAdd.java
@@ -3,7 +3,9 @@ package fr.inria.diversify.dspot.amplifier;
 
 import fr.inria.diversify.dspot.amplifier.value.ValueCreator;
 import fr.inria.diversify.utils.AmplificationHelper;
+import fr.inria.diversify.utils.DSpotUtils;
 import fr.inria.diversify.utils.TypeUtils;
+import org.kevoree.log.Log;
 import spoon.reflect.code.*;
 import spoon.reflect.declaration.*;
 import spoon.reflect.factory.Factory;
@@ -23,44 +25,45 @@ import java.util.stream.Stream;
  */
 public class StatementAdd implements Amplifier {
 
+	private boolean shouldGenerateNewObject = true;// TODO
 	private int counterGenerateNewObject = 0;
 	private String filter;
 	private Set<CtMethod> methods;
-	private Map<CtType, Boolean> hasConstructor;
 
 	public StatementAdd() {
 		this.filter = "";
-		this.hasConstructor = new HashMap<>();
 	}
 
 	public StatementAdd(String filter) {
 		this.filter = filter;
-		this.hasConstructor = new HashMap<>();
 	}
 
 	@Override
 	public List<CtMethod> apply(CtMethod method) {
-		// generate new objects
-		final List<CtMethod<?>> generateNewObjects = generateNewObjects(method);
-
 		// reuse existing object in test to add call to methods
 		final List<CtMethod> useExistingObject = useExistingObject(method); // original
-		useExistingObject.addAll(generateNewObjects.stream() // + generated at previous step
-				.flatMap(ctMethod -> useExistingObject(ctMethod).stream())
-				.collect(Collectors.toList())
-		);
-
 		// use results of existing method call to generate new statement.
 		final List<CtMethod> useReturnValuesOfExistingMethodCall = useReturnValuesOfExistingMethodCall(method);  // original
-		useReturnValuesOfExistingMethodCall.addAll(generateNewObjects.stream() // + generated at previous step
-				.flatMap(ctMethod -> useReturnValuesOfExistingMethodCall(ctMethod).stream())
-				.collect(Collectors.toList()));
-
 		useExistingObject.addAll(useReturnValuesOfExistingMethodCall);
+		if (shouldGenerateNewObject) {
+			useExistingObject.addAll(generateOnNewObjects(method));
+		}
 		return useExistingObject;
 	}
 
-	private List<CtMethod<?>> generateNewObjects(CtMethod method) {
+	private List<CtMethod> generateOnNewObjects(CtMethod method) {
+		// generate new objects
+		final List<CtMethod> generateNewObjects = generateNewObjects(method);
+		final List<CtMethod> methodsWithMoreStatement = generateNewObjects.stream() // + generated at previous step
+				.flatMap(ctMethod -> useExistingObject(ctMethod).stream())
+				.collect(Collectors.toList());
+		methodsWithMoreStatement.addAll(generateNewObjects.stream() // + generated at previous step
+				.flatMap(ctMethod -> useReturnValuesOfExistingMethodCall(ctMethod).stream())
+				.collect(Collectors.toList()));
+		return methodsWithMoreStatement;
+	}
+
+	private List<CtMethod> generateNewObjects(CtMethod method) {
 		List<CtLocalVariable<?>> existingObjects = getExistingObjects(method);
 		final Stream<? extends CtMethod<?>> gen_o1 = existingObjects.stream() // must use tmp variable because javac is confused
 				.flatMap(localVariable -> ValueCreator.generateAllConstructionOf(localVariable.getType()).stream())
@@ -139,15 +142,21 @@ public class StatementAdd implements Amplifier {
 		initMethods(testClass);
 	}
 
-	private CtMethod addInvocation(CtMethod<?> method, CtMethod<?> mthToAdd, CtExpression<?> target, CtStatement position) {
-		final Factory factory = method.getFactory();
-		CtMethod methodClone = AmplificationHelper.cloneMethodTest(method, "_sd");
+	private CtMethod addInvocation(CtMethod<?> testMethod, CtMethod<?> methodToInvokeToAdd, CtExpression<?> target, CtStatement position) {
+		final Factory factory = testMethod.getFactory();
+		CtMethod methodClone = AmplificationHelper.cloneMethodTest(testMethod, "_sd");
 
-		CtBlock body = methodClone.getBody();
-		List<CtParameter<?>> parameters = mthToAdd.getParameters();
+		CtBlock body = methodClone.getElements(new TypeFilter<>(CtStatement.class))
+				.stream()
+				.filter(statement -> statement.equals(position))
+				.findFirst()
+				.get()
+				.getParent(CtBlock.class);
+
+		List<CtParameter<?>> parameters = methodToInvokeToAdd.getParameters();
 		List<CtExpression<?>> arguments = new ArrayList<>(parameters.size());
 
-		mthToAdd.getParameters().forEach(parameter -> {
+		methodToInvokeToAdd.getParameters().forEach(parameter -> {
 					try {
 						CtLocalVariable<?> localVariable = ValueCreator.createRandomLocalVar(parameter.getType(), parameter.getSimpleName());
 						body.insertBegin(localVariable);
@@ -156,13 +165,10 @@ public class StatementAdd implements Amplifier {
 						throw new RuntimeException(e);
 					}
 				});
-
 		CtExpression targetClone = target.clone();
-		CtInvocation newInvocation = factory.Code().createInvocation(targetClone, mthToAdd.getReference(), arguments);
-
-		CtStatement stmt = findInvocationIn(methodClone, position);
-		stmt.insertAfter(newInvocation);
-
+		CtInvocation newInvocation = factory.Code().createInvocation(targetClone, methodToInvokeToAdd.getReference(), arguments);
+		DSpotUtils.addComment(newInvocation, "StatementAdd: add invocation of a method", CtComment.CommentType.INLINE);
+		body.insertEnd(newInvocation);
 		return methodClone;
 	}
 
@@ -184,7 +190,11 @@ public class StatementAdd implements Amplifier {
 			return Collections.emptyList();
 		} else {
 			return methods.stream()
-					.filter(mth -> mth.getDeclaringType().getReference().getQualifiedName().equals(type.getQualifiedName()))
+					.filter(method ->
+							method.getDeclaringType().getReference().getQualifiedName()
+									.equals(type.getQualifiedName())
+					)
+					.filter(method -> method.getModifiers().contains(ModifierKind.PUBLIC))
 					.collect(Collectors.toList());
 		}
 	}

--- a/src/main/java/fr/inria/diversify/dspot/amplifier/StatementAdd.java
+++ b/src/main/java/fr/inria/diversify/dspot/amplifier/StatementAdd.java
@@ -44,11 +44,11 @@ public class StatementAdd implements Amplifier {
 		final List<CtMethod<?>> generateNewObjects = generateNewObjects(method);
 
 		// reuse existing object in test to add call to methods
-		List<CtMethod> useExistingObject = useExistingObject(method); // original
-		useExistingObject.addAll(generateNewObjects);
-		useExistingObject = useExistingObject.stream() // + generated at previous step
+		final List<CtMethod> useExistingObject = useExistingObject(method); // original
+		useExistingObject.addAll(generateNewObjects.stream() // + generated at previous step
 				.flatMap(ctMethod -> useExistingObject(ctMethod).stream())
-				.collect(Collectors.toList());
+				.collect(Collectors.toList())
+		);
 
 		// use results of existing method call to generate new statement.
 		final List<CtMethod> useReturnValuesOfExistingMethodCall = useReturnValuesOfExistingMethodCall(method);  // original

--- a/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertBuilder.java
+++ b/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertBuilder.java
@@ -16,206 +16,208 @@ import java.util.stream.Collectors;
  */
 public class AssertBuilder {
 
-	private static String junitAssertClassName = "org.junit.Assert";
+    private static String junitAssertClassName = "org.junit.Assert";
 
-	static List<CtStatement> buildAssert(Factory factory, Set<String> notDeterministValues, Map<String, Object> observations) {
-		return observations.keySet().stream()
-				.filter(key -> !notDeterministValues.contains(key))
-				.collect(ArrayList<CtStatement>::new,
-						(expressions, key) -> {
-							Object value = observations.get(key);
-							final CtVariableAccess<?> variableRead = factory.createVariableRead(
-									factory.createLocalVariableReference().setSimpleName(key),
-									false
-							);
-							if (value == null) {
-								expressions.add(buildInvocation(factory, "assertNull",
-										Collections.singletonList(variableRead))
-								);
-							} else if (value instanceof Boolean) {
-								expressions.add(
-										buildInvocation(factory,
-												(Boolean) value ? "assertTrue" : "assertFalse",
-												Collections.singletonList(variableRead)
-										)
-								);
-							} else if (TypeUtils.isArray(value)) {//TODO
-								expressions.add(buildAssertForArray(factory, key, value));
-							} else if (TypeUtils.isPrimitiveCollection(value)) {
-								Collection valueCollection = (Collection) value;
-								if (valueCollection.isEmpty()) {
-									final CtInvocation<?> isEmpty = factory.createInvocation(variableRead,
-											factory.Type().get(Collection.class).getMethodsByName("isEmpty").get(0).getReference()
-									);
-									expressions.add(buildInvocation(factory, "assertTrue",
-											Collections.singletonList(isEmpty))
-									);
-								} else {
-									expressions.addAll(buildSnippetAssertCollection(factory, key, (Collection) value));
-								}
-							} else if (TypeUtils.isPrimitiveMap(value)) {//TODO
-								expressions.add(buildSnippetAssertMap(factory, key, (Map) value));
-							} else {
-								addTypeCastIfNeeded(variableRead, value);
-								expressions.add(buildInvocation(factory, "assertEquals",
-										Arrays.asList(printPrimitiveString(factory, value),
-												variableRead)));
-							}
-						},
-						ArrayList<CtStatement>::addAll);
-	}
+    static List<CtStatement> buildAssert(Factory factory, Set<String> notDeterministValues, Map<String, Object> observations) {
+        return observations.keySet().stream()
+                .filter(key -> !notDeterministValues.contains(key))
+                .filter(key -> !(observations.get(key) instanceof Float ||
+                        observations.get(key) instanceof Double))
+                .collect(ArrayList<CtStatement>::new,
+                        (expressions, key) -> {
+                            Object value = observations.get(key);
+                            final CtVariableAccess<?> variableRead = factory.createVariableRead(
+                                    factory.createLocalVariableReference().setSimpleName(key),
+                                    false
+                            );
+                            if (value == null) {
+                                expressions.add(buildInvocation(factory, "assertNull",
+                                        Collections.singletonList(variableRead))
+                                );
+                            } else if (value instanceof Boolean) {
+                                expressions.add(
+                                        buildInvocation(factory,
+                                                (Boolean) value ? "assertTrue" : "assertFalse",
+                                                Collections.singletonList(variableRead)
+                                        )
+                                );
+                            } else if (TypeUtils.isArray(value)) {//TODO
+                                expressions.add(buildAssertForArray(factory, key, value));
+                            } else if (TypeUtils.isPrimitiveCollection(value)) {
+                                Collection valueCollection = (Collection) value;
+                                if (valueCollection.isEmpty()) {
+                                    final CtInvocation<?> isEmpty = factory.createInvocation(variableRead,
+                                            factory.Type().get(Collection.class).getMethodsByName("isEmpty").get(0).getReference()
+                                    );
+                                    expressions.add(buildInvocation(factory, "assertTrue",
+                                            Collections.singletonList(isEmpty))
+                                    );
+                                } else {
+                                    expressions.addAll(buildSnippetAssertCollection(factory, key, (Collection) value));
+                                }
+                            } else if (TypeUtils.isPrimitiveMap(value)) {//TODO
+                                expressions.add(buildSnippetAssertMap(factory, key, (Map) value));
+                            } else {
+                                addTypeCastIfNeeded(variableRead, value);
+                                expressions.add(buildInvocation(factory, "assertEquals",
+                                        Arrays.asList(printPrimitiveString(factory, value),
+                                                variableRead)));
+                            }
+                        },
+                        ArrayList<CtStatement>::addAll);
+    }
 
-	private static void addTypeCastIfNeeded(CtVariableAccess<?> variableRead, Object value) {
-		if (value instanceof Short) {
-			variableRead.addTypeCast(variableRead.getFactory().Type().shortPrimitiveType());
-		} else if (value instanceof Integer) {
-			variableRead.addTypeCast(variableRead.getFactory().Type().integerPrimitiveType());
-		} else if (value instanceof Long) {
-			variableRead.addTypeCast(variableRead.getFactory().Type().longPrimitiveType());
-		} else if (value instanceof Byte) {
-			variableRead.addTypeCast(variableRead.getFactory().Type().bytePrimitiveType());
-		} else if (value instanceof Float) {
-			variableRead.addTypeCast(variableRead.getFactory().Type().floatPrimitiveType());
-		} else if (value instanceof Double) {
-			variableRead.addTypeCast(variableRead.getFactory().Type().doublePrimitiveType());
-		} else if (value instanceof Character) {
-			variableRead.addTypeCast(variableRead.getFactory().Type().characterPrimitiveType());
-		}
-	}
+    private static void addTypeCastIfNeeded(CtVariableAccess<?> variableRead, Object value) {
+        if (value instanceof Short) {
+            variableRead.addTypeCast(variableRead.getFactory().Type().shortPrimitiveType());
+        } else if (value instanceof Integer) {
+            variableRead.addTypeCast(variableRead.getFactory().Type().integerPrimitiveType());
+        } else if (value instanceof Long) {
+            variableRead.addTypeCast(variableRead.getFactory().Type().longPrimitiveType());
+        } else if (value instanceof Byte) {
+            variableRead.addTypeCast(variableRead.getFactory().Type().bytePrimitiveType());
+        } else if (value instanceof Float) {
+            variableRead.addTypeCast(variableRead.getFactory().Type().floatPrimitiveType());
+        } else if (value instanceof Double) {
+            variableRead.addTypeCast(variableRead.getFactory().Type().doublePrimitiveType());
+        } else if (value instanceof Character) {
+            variableRead.addTypeCast(variableRead.getFactory().Type().characterPrimitiveType());
+        }
+    }
 
-	private static CtInvocation buildInvocation(Factory factory, String methodName, List<CtExpression> arguments) {
-		final CtInvocation invocation = factory.createInvocation();
-		final CtExecutableReference<?> executableReference = factory.Core().createExecutableReference();
-		executableReference.setStatic(true);
-		executableReference.setSimpleName(methodName);
-		executableReference.setDeclaringType(factory.createCtTypeReference(org.junit.Assert.class));
-		invocation.setExecutable(executableReference);
-		invocation.setArguments(arguments); // TODO
-		invocation.setType(factory.Type().voidPrimitiveType());
-		invocation.setTarget(factory.createTypeAccess(factory.createCtTypeReference(org.junit.Assert.class)));
-		return invocation;
-	}
+    private static CtInvocation buildInvocation(Factory factory, String methodName, List<CtExpression> arguments) {
+        final CtInvocation invocation = factory.createInvocation();
+        final CtExecutableReference<?> executableReference = factory.Core().createExecutableReference();
+        executableReference.setStatic(true);
+        executableReference.setSimpleName(methodName);
+        executableReference.setDeclaringType(factory.createCtTypeReference(org.junit.Assert.class));
+        invocation.setExecutable(executableReference);
+        invocation.setArguments(arguments); // TODO
+        invocation.setType(factory.Type().voidPrimitiveType());
+        invocation.setTarget(factory.createTypeAccess(factory.createCtTypeReference(org.junit.Assert.class)));
+        return invocation;
+    }
 
-	private static CtStatement buildAssertForArray(Factory factory, String expression, Object array) {
-		String type = array.getClass().getCanonicalName();
-		String arrayLocalVar1 = "array_" + Math.abs(AmplificationHelper.getRandom().nextInt());
-		String arrayLocalVar2 = "array_" + Math.abs(AmplificationHelper.getRandom().nextInt());
+    private static CtStatement buildAssertForArray(Factory factory, String expression, Object array) {
+        String type = array.getClass().getCanonicalName();
+        String arrayLocalVar1 = "array_" + Math.abs(AmplificationHelper.getRandom().nextInt());
+        String arrayLocalVar2 = "array_" + Math.abs(AmplificationHelper.getRandom().nextInt());
 
 
-		String forLoop = "\tfor(int ii = 0; ii <" + arrayLocalVar1 + ".length; ii++) {\n\t\t"
-				+ junitAssertClassName + ".assertEquals(" + arrayLocalVar1 + "[ii], " + arrayLocalVar2 + "[ii]);\n\t}";
+        String forLoop = "\tfor(int ii = 0; ii <" + arrayLocalVar1 + ".length; ii++) {\n\t\t"
+                + junitAssertClassName + ".assertEquals(" + arrayLocalVar1 + "[ii], " + arrayLocalVar2 + "[ii]);\n\t}";
 
-		return factory.createCodeSnippetStatement(type + " " + arrayLocalVar1 + " = " + primitiveArrayToString(array) + ";\n\t"
-				+ type + " " + arrayLocalVar2 + " = " + "(" + type + ")" + expression + ";\n"
-				+ forLoop);
-	}
+        return factory.createCodeSnippetStatement(type + " " + arrayLocalVar1 + " = " + primitiveArrayToString(array) + ";\n\t"
+                + type + " " + arrayLocalVar2 + " = " + "(" + type + ")" + expression + ";\n"
+                + forLoop);
+    }
 
-	@SuppressWarnings("unchecked")
-	private static List<CtStatement> buildSnippetAssertCollection(Factory factory, String expression, Collection value) {
-		final CtVariableAccess variableRead = factory.createVariableRead(
-				factory.createLocalVariableReference().setSimpleName(expression),
-				false
-		);
-		final CtExecutableReference contains = factory.Type().get(Collection.class).getMethodsByName("contains").get(0).getReference();
-		return (List<CtStatement>) value.stream().map(factory::createLiteral)
-				.map(o ->
-						buildInvocation(factory, "assertTrue",
-								Collections.singletonList(factory.createInvocation(variableRead,
-										contains, (CtLiteral) o
-										)
-								)
-						)
-				)
-				.collect(Collectors.toList());
-	}
+    @SuppressWarnings("unchecked")
+    private static List<CtStatement> buildSnippetAssertCollection(Factory factory, String expression, Collection value) {
+        final CtVariableAccess variableRead = factory.createVariableRead(
+                factory.createLocalVariableReference().setSimpleName(expression),
+                false
+        );
+        final CtExecutableReference contains = factory.Type().get(Collection.class).getMethodsByName("contains").get(0).getReference();
+        return (List<CtStatement>) value.stream().map(factory::createLiteral)
+                .map(o ->
+                        buildInvocation(factory, "assertTrue",
+                                Collections.singletonList(factory.createInvocation(variableRead,
+                                        contains, (CtLiteral) o
+                                        )
+                                )
+                        )
+                )
+                .collect(Collectors.toList());
+    }
 
-	private static CtStatement buildSnippetAssertMap(Factory factory, String expression, Map value) {
-		Random r = new Random();
-		String type = value.getClass().getCanonicalName();
-		String localVar = "map_" + Math.abs(r.nextInt());
-		String newCollection = type + " " + localVar + " = new " + type + "<Object, Object>();";
+    private static CtStatement buildSnippetAssertMap(Factory factory, String expression, Map value) {
+        Random r = new Random();
+        String type = value.getClass().getCanonicalName();
+        String localVar = "map_" + Math.abs(r.nextInt());
+        String newCollection = type + " " + localVar + " = new " + type + "<Object, Object>();";
 
-		Set<Map.Entry> set = value.entrySet();
-		for (Map.Entry v : set) {
-			newCollection += "\n\t" + localVar + ".put(" + printPrimitiveString(factory, v.getKey())
-					+ ", " + printPrimitiveString(factory, v.getValue()) + ");\n";
-		}
-		newCollection += "\t" + junitAssertClassName + ".assertEquals(" + localVar + ", " + expression + ");";
+        Set<Map.Entry> set = value.entrySet();
+        for (Map.Entry v : set) {
+            newCollection += "\n\t" + localVar + ".put(" + printPrimitiveString(factory, v.getKey())
+                    + ", " + printPrimitiveString(factory, v.getValue()) + ");\n";
+        }
+        newCollection += "\t" + junitAssertClassName + ".assertEquals(" + localVar + ", " + expression + ");";
 
-		return factory.createCodeSnippetStatement(newCollection);
-	}
+        return factory.createCodeSnippetStatement(newCollection);
+    }
 
-	private static CtExpression printPrimitiveString(Factory factory, Object value) {
-		if (value == null || value instanceof String ||
-				value instanceof Short ||
-				value.getClass() == short.class ||
-				value instanceof Double ||
-				value.getClass() == double.class ||
-				value instanceof Float ||
-				value.getClass() == float.class ||
-				value instanceof Long ||
-				value.getClass() == long.class ||
-				value instanceof Character ||
-				value.getClass() == char.class ||
-				value instanceof Byte ||
-				value.getClass() == byte.class ||
-				value instanceof Integer ||
-				value.getClass() == int.class) {
-			return factory.createLiteral(value);
-		} else {
-			return factory.createCodeSnippetExpression(value.toString());
-		}
-	}
+    private static CtExpression printPrimitiveString(Factory factory, Object value) {
+        if (value == null || value instanceof String ||
+                value instanceof Short ||
+                value.getClass() == short.class ||
+                value instanceof Double ||
+                value.getClass() == double.class ||
+                value instanceof Float ||
+                value.getClass() == float.class ||
+                value instanceof Long ||
+                value.getClass() == long.class ||
+                value instanceof Character ||
+                value.getClass() == char.class ||
+                value instanceof Byte ||
+                value.getClass() == byte.class ||
+                value instanceof Integer ||
+                value.getClass() == int.class) {
+            return factory.createLiteral(value);
+        } else {
+            return factory.createCodeSnippetExpression(value.toString());
+        }
+    }
 
-	private static String primitiveArrayToString(Object array) {
-		String type = array.getClass().getCanonicalName();
+    private static String primitiveArrayToString(Object array) {
+        String type = array.getClass().getCanonicalName();
 
-		String tmp;
-		if (type.equals("int[]")) {
-			tmp = Arrays.toString((int[]) array);
-			return "new int[]{" + tmp.substring(1, tmp.length() - 1) + "}";
-		}
-		if (type.equals("short[]")) {
-			tmp = Arrays.toString((short[]) array);
-			return "new short[]{" + tmp.substring(1, tmp.length() - 1) + "}";
-		}
-		if (type.equals("byte[]")) {
-			tmp = Arrays.toString((byte[]) array);
-			return "new byte[]{" + tmp.substring(1, tmp.length() - 1) + "}";
-		}
-		if (type.equals("long[]")) {
-			tmp = Arrays.toString((long[]) array);
-			return "new long[]{" + tmp.substring(1, tmp.length() - 1) + "}";
-		}
-		if (type.equals("float[]")) {
-			tmp = Arrays.toString((float[]) array);
-			return "new float[]{" + tmp.substring(1, tmp.length() - 1) + "}";
-		}
-		if (type.equals("double[]")) {
-			tmp = Arrays.toString((double[]) array);
-			return "new double[]{" + tmp.substring(1, tmp.length() - 1) + "}";
-		}
-		if (type.equals("boolean[]")) {
-			tmp = Arrays.toString((boolean[]) array);
-			return "new boolean[]{" + tmp.substring(1, tmp.length() - 1) + "}";
-		}
-		if (type.equals("char[]")) {
-			char[] arrayChar = (char[]) array;
+        String tmp;
+        if (type.equals("int[]")) {
+            tmp = Arrays.toString((int[]) array);
+            return "new int[]{" + tmp.substring(1, tmp.length() - 1) + "}";
+        }
+        if (type.equals("short[]")) {
+            tmp = Arrays.toString((short[]) array);
+            return "new short[]{" + tmp.substring(1, tmp.length() - 1) + "}";
+        }
+        if (type.equals("byte[]")) {
+            tmp = Arrays.toString((byte[]) array);
+            return "new byte[]{" + tmp.substring(1, tmp.length() - 1) + "}";
+        }
+        if (type.equals("long[]")) {
+            tmp = Arrays.toString((long[]) array);
+            return "new long[]{" + tmp.substring(1, tmp.length() - 1) + "}";
+        }
+        if (type.equals("float[]")) {
+            tmp = Arrays.toString((float[]) array);
+            return "new float[]{" + tmp.substring(1, tmp.length() - 1) + "}";
+        }
+        if (type.equals("double[]")) {
+            tmp = Arrays.toString((double[]) array);
+            return "new double[]{" + tmp.substring(1, tmp.length() - 1) + "}";
+        }
+        if (type.equals("boolean[]")) {
+            tmp = Arrays.toString((boolean[]) array);
+            return "new boolean[]{" + tmp.substring(1, tmp.length() - 1) + "}";
+        }
+        if (type.equals("char[]")) {
+            char[] arrayChar = (char[]) array;
 
-			if (arrayChar.length == 0) {
-				return "new char[]{}";
-			}
-			if (arrayChar.length == 1) {
-				return "new char[]{\'" + arrayChar[0] + "\'}";
-			} else {
-				String ret = "new char[]{\'" + arrayChar[0];
-				for (int i = 1; i < arrayChar.length - 1; i++) {
-					ret += "\',\'" + arrayChar[i];
-				}
-				return ret + "\'}";
-			}
-		}
-		return null;
-	}
+            if (arrayChar.length == 0) {
+                return "new char[]{}";
+            }
+            if (arrayChar.length == 1) {
+                return "new char[]{\'" + arrayChar[0] + "\'}";
+            } else {
+                String ret = "new char[]{\'" + arrayChar[0];
+                for (int i = 1; i < arrayChar.length - 1; i++) {
+                    ret += "\',\'" + arrayChar[i];
+                }
+                return ret + "\'}";
+            }
+        }
+        return null;
+    }
 
 }

--- a/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorHelper.java
+++ b/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorHelper.java
@@ -31,127 +31,135 @@ import static fr.inria.diversify.utils.AmplificationChecker.isAssert;
  */
 public class AssertGeneratorHelper {
 
-	static boolean isVoidReturn(CtInvocation invocation) {
-		return (invocation.getType() != null && (invocation.getType().equals(invocation.getFactory().Type().voidType()) ||
-				invocation.getType().equals(invocation.getFactory().Type().voidPrimitiveType())));
-	}
+    static boolean isVoidReturn(CtInvocation invocation) {
+        return (invocation.getType() != null && (invocation.getType().equals(invocation.getFactory().Type().voidType()) ||
+                invocation.getType().equals(invocation.getFactory().Type().voidPrimitiveType())));
+    }
 
-	static CtMethod<?> createTestWithLog(CtMethod test, final String filter) {
-		CtMethod clone = AmplificationHelper.cloneMethodTest(test, "");
-		clone.setSimpleName(test.getSimpleName() + "_withlog");
-		final List<CtStatement> allStatement = clone.getElements(new TypeFilter<>(CtStatement.class));
-		allStatement.stream()
-				.filter(statement -> isStmtToLog(filter, statement))
-				.forEach(statement ->
-						addLogStmt(statement,
-								test.getSimpleName() + "__" + indexOfByRef(allStatement, statement))
-				);
-		return clone;
-	}
+    static CtMethod<?> createTestWithLog(CtMethod test, final String filter) {
+        CtMethod clone = AmplificationHelper.cloneMethodTest(test, "");
+        clone.setSimpleName(test.getSimpleName() + "_withlog");
+        final List<CtStatement> allStatement = clone.getElements(new TypeFilter<>(CtStatement.class));
+        allStatement.stream()
+                .filter(statement -> isStmtToLog(filter, statement))
+                .forEach(statement ->
+                        addLogStmt(statement,
+                                test.getSimpleName() + "__" + indexOfByRef(allStatement, statement))
+                );
+        return clone;
+    }
 
-	private static int indexOfByRef(List<CtStatement> statements, CtStatement statement) {
-		for (int i = 0; i < statements.size(); i++) {
-			if (statements.get(i) == statement) {
-				return i;
-			}
-		}
-		return -1;
-	}
+    private static int indexOfByRef(List<CtStatement> statements, CtStatement statement) {
+        for (int i = 0; i < statements.size(); i++) {
+            if (statements.get(i) == statement) {
+                return i;
+            }
+        }
+        return -1;
+    }
 
-	private static boolean isStmtToLog(String filter, CtStatement statement) {
-		if (!(statement.getParent() instanceof CtBlock)) {
-			return false;
-		}
-		if (statement instanceof CtInvocation) {
-			CtInvocation invocation = (CtInvocation) statement;
+    private static boolean isGetter(CtInvocation invocation) {
+        return invocation.getArguments().isEmpty() &&
+                (invocation.getExecutable().getSimpleName().startsWith("is") ||
+                        invocation.getExecutable().getSimpleName().startsWith("get") ||
+                        invocation.getExecutable().getSimpleName().startsWith("should")
+                );
+    }
 
-			//type tested by the test class
-			String targetType = "";
-			if (invocation.getTarget() != null &&
-					invocation.getTarget().getType() != null) {
-				targetType = invocation.getTarget().getType().getSimpleName();
-			}
-			return (filter.startsWith(targetType)
-					|| !isVoidReturn(invocation));
-		}
-		if (statement instanceof CtLocalVariable ||
-				statement instanceof CtAssignment ||
-				statement instanceof CtVariableWrite) {
-			final CtTypeReference type = ((CtTypedElement) statement).getType();
-			if (type.getQualifiedName().startsWith(filter) ||
-					type.isPrimitive()) {
-				return true;
-			} else {
-				try {
-					return type.getActualClass() == String.class;
-				} catch (SpoonClassNotFoundException e) {
-					return false;
-				}
-			}
-		} else {
-			return false;
-		}
-	}
+    private static boolean isStmtToLog(String filter, CtStatement statement) {
+        if (!(statement.getParent() instanceof CtBlock)) {
+            return false;
+        }
+        if (statement instanceof CtInvocation) {
+            CtInvocation invocation = (CtInvocation) statement;
+            //type tested by the test class
+            String targetType = "";
+            if (invocation.getTarget() != null &&
+                    invocation.getTarget().getType() != null) {
+                targetType = invocation.getTarget().getType().getSimpleName();
+            }
+            return (filter.startsWith(targetType)
+                    || !isVoidReturn(invocation)
+                    && !isGetter(invocation));
+        }
+        if (statement instanceof CtLocalVariable ||
+                statement instanceof CtAssignment ||
+                statement instanceof CtVariableWrite) {
+            final CtTypeReference type = ((CtTypedElement) statement).getType();
+            if (type.getQualifiedName().startsWith(filter) ||
+                    !type.isPrimitive()) {
+                return true;
+            } else {
+                try {
+                    return type.getActualClass() == String.class;
+                } catch (SpoonClassNotFoundException e) {
+                    return false;
+                }
+            }
+        } else {
+            return false;
+        }
+    }
 
 
-	@SuppressWarnings("unchecked")
-	private static void addLogStmt(CtStatement stmt, String id) {
-		if (stmt instanceof CtLocalVariable && ((CtLocalVariable) stmt).getDefaultExpression() == null) {
-			return;
-		}
+    @SuppressWarnings("unchecked")
+    private static void addLogStmt(CtStatement stmt, String id) {
+        if (stmt instanceof CtLocalVariable && ((CtLocalVariable) stmt).getDefaultExpression() == null) {
+            return;
+        }
 
-		final CtTypeAccess<ObjectLog> typeAccess = stmt.getFactory().createTypeAccess(
-				stmt.getFactory().Type().createReference(ObjectLog.class)
-		);
+        final CtTypeAccess<ObjectLog> typeAccess = stmt.getFactory().createTypeAccess(
+                stmt.getFactory().Type().createReference(ObjectLog.class)
+        );
 
-		final CtExecutableReference objectLogExecRef = stmt.getFactory().createExecutableReference()
-				.setStatic(true)
-				.setDeclaringType(stmt.getFactory().Type().createReference(ObjectLog.class))
-				.setSimpleName("log");
-		objectLogExecRef.setType(stmt.getFactory().Type().voidPrimitiveType());
+        final CtExecutableReference objectLogExecRef = stmt.getFactory().createExecutableReference()
+                .setStatic(true)
+                .setDeclaringType(stmt.getFactory().Type().createReference(ObjectLog.class))
+                .setSimpleName("log");
+        objectLogExecRef.setType(stmt.getFactory().Type().voidPrimitiveType());
 
-		final CtInvocation invocationToObjectLog = stmt.getFactory().createInvocation(typeAccess, objectLogExecRef);
+        final CtInvocation invocationToObjectLog = stmt.getFactory().createInvocation(typeAccess, objectLogExecRef);
 
-		CtStatement insertAfter;
-		if (stmt instanceof CtVariableWrite) {//TODO
-			CtVariableWrite varWrite = (CtVariableWrite) stmt;
-			insertAfter = stmt;
-		} else if (stmt instanceof CtLocalVariable) {
-			CtLocalVariable localVar = (CtLocalVariable) stmt;
-			final CtVariableAccess variableRead = stmt.getFactory().createVariableRead(localVar.getReference(), false);// TODO checks static
-			invocationToObjectLog.addArgument(variableRead);
-			invocationToObjectLog.addArgument(stmt.getFactory().createLiteral(localVar.getSimpleName()));
-			insertAfter = stmt;
-		} else if (stmt instanceof CtAssignment) {
-			CtAssignment localVar = (CtAssignment) stmt;
-			invocationToObjectLog.addArgument(localVar.getAssigned());
-			invocationToObjectLog.addArgument(stmt.getFactory().createLiteral(localVar.getAssigned().toString()));
-			insertAfter = stmt;
-		} else if (stmt instanceof CtInvocation) {
-			CtInvocation invocation = (CtInvocation) stmt;
-			if (isVoidReturn(invocation)) {
-				invocationToObjectLog.addArgument(invocation.getTarget());
-				invocationToObjectLog.addArgument(stmt.getFactory().createLiteral(
-						invocation.getTarget().toString().replace("\"", "\\\""))
-				);
-				insertAfter = invocation;
-			} else {
-				final CtLocalVariable localVariable = stmt.getFactory().createLocalVariable(invocation.getType(),
-						"o_" + id, invocation.clone());
-				try {
-					stmt.replace(localVariable);
-				} catch (ClassCastException e) {
-					throw new RuntimeException(e);
-				}
-				invocationToObjectLog.addArgument(stmt.getFactory().createVariableRead(localVariable.getReference(), false));
-				invocationToObjectLog.addArgument(stmt.getFactory().createLiteral("o_" + id));
-				insertAfter = localVariable;
-			}
-		} else {
-			throw new RuntimeException("Could not find the proper type to add log statement" + stmt.toString());
-		}
-		invocationToObjectLog.addArgument(stmt.getFactory().createLiteral(id));
-		insertAfter.insertAfter(invocationToObjectLog);
-	}
+        CtStatement insertAfter;
+        if (stmt instanceof CtVariableWrite) {//TODO
+            CtVariableWrite varWrite = (CtVariableWrite) stmt;
+            insertAfter = stmt;
+        } else if (stmt instanceof CtLocalVariable) {
+            CtLocalVariable localVar = (CtLocalVariable) stmt;
+            final CtVariableAccess variableRead = stmt.getFactory().createVariableRead(localVar.getReference(), false);// TODO checks static
+            invocationToObjectLog.addArgument(variableRead);
+            invocationToObjectLog.addArgument(stmt.getFactory().createLiteral(localVar.getSimpleName()));
+            insertAfter = stmt;
+        } else if (stmt instanceof CtAssignment) {
+            CtAssignment localVar = (CtAssignment) stmt;
+            invocationToObjectLog.addArgument(localVar.getAssigned());
+            invocationToObjectLog.addArgument(stmt.getFactory().createLiteral(localVar.getAssigned().toString()));
+            insertAfter = stmt;
+        } else if (stmt instanceof CtInvocation) {
+            CtInvocation invocation = (CtInvocation) stmt;
+            if (isVoidReturn(invocation)) {
+                invocationToObjectLog.addArgument(invocation.getTarget());
+                invocationToObjectLog.addArgument(stmt.getFactory().createLiteral(
+                        invocation.getTarget().toString().replace("\"", "\\\""))
+                );
+                insertAfter = invocation;
+            } else {
+                final CtLocalVariable localVariable = stmt.getFactory().createLocalVariable(invocation.getType(),
+                        "o_" + id, invocation.clone());
+                try {
+                    stmt.replace(localVariable);
+                } catch (ClassCastException e) {
+                    throw new RuntimeException(e);
+                }
+                invocationToObjectLog.addArgument(stmt.getFactory().createVariableRead(localVariable.getReference(), false));
+                invocationToObjectLog.addArgument(stmt.getFactory().createLiteral("o_" + id));
+                insertAfter = localVariable;
+            }
+        } else {
+            throw new RuntimeException("Could not find the proper type to add log statement" + stmt.toString());
+        }
+        invocationToObjectLog.addArgument(stmt.getFactory().createLiteral(id));
+        insertAfter.insertAfter(invocationToObjectLog);
+    }
 
 }

--- a/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorHelper.java
+++ b/src/main/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorHelper.java
@@ -76,18 +76,21 @@ public class AssertGeneratorHelper {
             String targetType = "";
             if (invocation.getTarget() != null &&
                     invocation.getTarget().getType() != null) {
-                targetType = invocation.getTarget().getType().getSimpleName();
+                targetType = invocation.getTarget().getType().getQualifiedName();
             }
-            return (filter.startsWith(targetType)
-                    || !isVoidReturn(invocation)
-                    && !isGetter(invocation));
+            if (targetType.startsWith(filter)) {
+                return (!isVoidReturn(invocation)
+                        && !isGetter(invocation));
+            } else {
+                return !isVoidReturn(invocation);
+            }
+
         }
         if (statement instanceof CtLocalVariable ||
                 statement instanceof CtAssignment ||
                 statement instanceof CtVariableWrite) {
             final CtTypeReference type = ((CtTypedElement) statement).getType();
-            if (type.getQualifiedName().startsWith(filter) ||
-                    !type.isPrimitive()) {
+            if (type.getQualifiedName().startsWith(filter)) {
                 return true;
             } else {
                 try {

--- a/src/main/java/fr/inria/diversify/dspot/assertGenerator/MethodsAssertGenerator.java
+++ b/src/main/java/fr/inria/diversify/dspot/assertGenerator/MethodsAssertGenerator.java
@@ -98,9 +98,7 @@ public class MethodsAssertGenerator {
 					generatedTestWithAssertion.addAll(failingTests);
 				}
 			}
-			return generatedTestWithAssertion.isEmpty() ?
-					generatedTestWithAssertion :
-					filterTest(clone, generatedTestWithAssertion, 3);
+			return generatedTestWithAssertion;
 		}
 	}
 
@@ -111,7 +109,7 @@ public class MethodsAssertGenerator {
 		final List<CtMethod<?>> testCasesWithLogs = testCases.stream()
 				.map(ctMethod ->
 						AssertGeneratorHelper.createTestWithLog(ctMethod,
-								this.originalClass.getSimpleName()
+								this.originalClass.getPackage().getQualifiedName()
 						)
 				).collect(Collectors.toList());
 		final List<CtMethod<?>> testToRuns = new ArrayList<>();
@@ -236,42 +234,5 @@ public class MethodsAssertGenerator {
 		AmplificationHelper.getAmpTestToParent().put(cloneMethodTest, test);
 
 		return cloneMethodTest;
-	}
-
-	private List<CtMethod<?>> filterTest(CtType clone, List<CtMethod<?>> tests, int nTime) {
-		final List<CtMethod<?>> clones = tests.stream()
-				.map(CtMethod::clone)
-				.collect(Collectors.toList());
-		clones.forEach(clone::addMethod);
-
-		for (int i = 0; i < nTime; i++) {
-			if (clones.isEmpty()) {
-				return Collections.emptyList();
-			}
-			final TestListener result = TestCompiler.compileAndRun(clone, false,
-					this.compiler, clones, this.configuration);
-			if (result == null) {
-				return Collections.emptyList();
-			} else {
-				result.getFailingTests()
-						.stream()
-						.map(Failure::getDescription)
-						.map(Description::getMethodName)
-						.forEach(failingTestMethodName -> {
-									final Optional<CtMethod<?>> failingTestMethod = clones.stream()
-											.filter(ctMethod ->
-													failingTestMethodName.equals(ctMethod.getSimpleName())
-											).findFirst();
-									if (failingTestMethod.isPresent()) {
-										final CtMethod<?> ctMethod = failingTestMethod.get();
-										clone.removeMethod(ctMethod);
-										clones.remove(ctMethod);
-									}
-								}
-
-						);
-			}
-		}
-		return clones;
 	}
 }

--- a/src/main/java/fr/inria/diversify/dspot/assertGenerator/MethodsAssertGenerator.java
+++ b/src/main/java/fr/inria/diversify/dspot/assertGenerator/MethodsAssertGenerator.java
@@ -32,216 +32,215 @@ import java.util.stream.IntStream;
  */
 public class MethodsAssertGenerator {
 
-	private int numberOfFail = 0;
+    private int numberOfFail = 0;
 
-	private CtType originalClass;
+    private CtType originalClass;
 
-	private Factory factory;
+    private Factory factory;
 
-	private InputConfiguration configuration;
+    private InputConfiguration configuration;
 
-	private DSpotCompiler compiler;
+    private DSpotCompiler compiler;
 
-	public MethodsAssertGenerator(CtType originalClass, InputConfiguration configuration, DSpotCompiler compiler) {
-		this.originalClass = originalClass;
-		this.configuration = configuration;
-		this.compiler = compiler;
-		this.factory = configuration.getInputProgram().getFactory();
-	}
+    public MethodsAssertGenerator(CtType originalClass, InputConfiguration configuration, DSpotCompiler compiler) {
+        this.originalClass = originalClass;
+        this.configuration = configuration;
+        this.compiler = compiler;
+        this.factory = configuration.getInputProgram().getFactory();
+    }
 
-	public List<CtMethod<?>> generateAsserts(CtType testClass, List<CtMethod<?>> tests) throws IOException, ClassNotFoundException {
-		CtType clone = testClass.clone();
-		testClass.getPackage().addType(clone);
-		tests.forEach(clone::addMethod);
+    public List<CtMethod<?>> generateAsserts(CtType testClass, List<CtMethod<?>> tests) throws IOException, ClassNotFoundException {
+        Log.info("Run tests. ({})", tests.size());
+        final TestListener result = TestCompiler.compileAndRun(testClass, false,
+                this.compiler, tests, this.configuration);
+        if (result == null) {
+            return Collections.emptyList();
+        } else {
+            final List<String> failuresMethodName = result.getFailingTests()
+                    .stream()
+                    .map(Failure::getDescription)
+                    .map(Description::getMethodName)
+                    .collect(Collectors.toList());
+            final List<String> passingMethodName = result.getPassingTests()
+                    .stream()
+                    .map(Description::getMethodName)
+                    .collect(Collectors.toList());
 
-		Log.info("Run tests. ({})", tests.size());
-		final TestListener result = TestCompiler.compileAndRun(clone, false,
-				this.compiler, tests, this.configuration);
-		if (result == null) {
-			return Collections.emptyList();
-		} else {
+            final List<CtMethod<?>> generatedTestWithAssertion = new ArrayList<>();
+            // add assertion on passing tests
+            if (!passingMethodName.isEmpty()) {
+                Log.info("{} test pass, generating assertion...", passingMethodName.size());
+                List<CtMethod<?>> passingTests = addAssertions(testClass,
+                        tests.stream()
+                                .filter(ctMethod -> passingMethodName.contains(ctMethod.getSimpleName()))
+                                .collect(Collectors.toList()))
+                        .stream()
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+                if (passingTests != null) {
+                    generatedTestWithAssertion.addAll(passingTests);
+                }
+            }
 
-			final List<String> failuresMethodName = result.getFailingTests()
-					.stream()
-					.map(Failure::getDescription)
-					.map(Description::getMethodName)
-					.collect(Collectors.toList());
-			final List<String> passingMethodName = result.getPassingTests()
-					.stream()
-					.map(Description::getMethodName)
-					.collect(Collectors.toList());
-
-			final List<CtMethod<?>> generatedTestWithAssertion = new ArrayList<>();
-			// add assertion on passing tests
-			if (!passingMethodName.isEmpty()) {
-				Log.info("{} test pass, generating assertion...", passingMethodName.size());
-				List<CtMethod<?>> passingTests = addAssertions(clone,
-						tests.stream()
-								.filter(ctMethod -> passingMethodName.contains(ctMethod.getSimpleName()))
-								.collect(Collectors.toList()))
-						.stream()
-						.filter(Objects::nonNull)
-						.collect(Collectors.toList());
-				if (passingTests != null) {
-					generatedTestWithAssertion.addAll(passingTests);
-				}
-			}
-
-			// add try/catch/fail on failing/error tests
-			if (!failuresMethodName.isEmpty()) {
-				Log.info("{} test fail, generating try/catch/fail blocks...", failuresMethodName.size());
-				final List<CtMethod<?>> failingTests = tests.stream()
-						.filter(ctMethod ->
-								failuresMethodName.contains(ctMethod.getSimpleName()))
-						.map(ctMethod ->
-								makeFailureTest(ctMethod, result.getFailureOf(ctMethod.getSimpleName()))
-						)
-						.filter(Objects::nonNull)
-						.collect(Collectors.toList());
-				if (!failingTests.isEmpty()) {
-					generatedTestWithAssertion.addAll(failingTests);
-				}
-			}
-			return generatedTestWithAssertion;
-		}
-	}
+            // add try/catch/fail on failing/error tests
+            if (!failuresMethodName.isEmpty()) {
+                Log.info("{} test fail, generating try/catch/fail blocks...", failuresMethodName.size());
+                final List<CtMethod<?>> failingTests = tests.stream()
+                        .filter(ctMethod ->
+                                failuresMethodName.contains(ctMethod.getSimpleName()))
+                        .map(ctMethod ->
+                                makeFailureTest(ctMethod, result.getFailureOf(ctMethod.getSimpleName()))
+                        )
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+                if (!failingTests.isEmpty()) {
+                    generatedTestWithAssertion.addAll(failingTests);
+                }
+            }
+            return generatedTestWithAssertion;
+        }
+    }
 
 
-	private List<CtMethod<?>> addAssertions(CtType<?> testClass, List<CtMethod<?>> testCases) throws IOException, ClassNotFoundException {
-		CtType clone = testClass.clone();
-		testClass.getPackage().addType(clone);
-		Log.info("Add observations points in passing tests.");
-		Log.info("Instrumentation...");
-		final List<CtMethod<?>> testCasesWithLogs = testCases.stream()
-				.map(ctMethod -> {
-							DSpotUtils.printProgress(testCases.indexOf(ctMethod), testCases.size());
-							return AssertGeneratorHelper.createTestWithLog(ctMethod,
-									this.originalClass.getPackage().getQualifiedName()
-							);}
-				).collect(Collectors.toList());
-		final List<CtMethod<?>> testToRuns = new ArrayList<>();
-		IntStream.range(0, 3).forEach(i -> {
-			testToRuns.addAll(
-					testCasesWithLogs.stream()
-							.map(CtMethod::clone)
-							.map(ctMethod -> {
-								ctMethod.setSimpleName(ctMethod.getSimpleName() + i);
-								return ctMethod;
-							})
-							.map(ctMethod -> {
-								clone.addMethod(ctMethod);
-								return ctMethod;
-							})
-							.collect(Collectors.toList())
-			);
-		});
-		ObjectLog.reset();
-		Log.info("Run instrumented tests. ({})", testToRuns.size());
-		final TestListener result = TestCompiler.compileAndRun(clone, true,
-				this.compiler, testToRuns, this.configuration);
-		if (result == null || !result.getFailingTests().isEmpty()) {
-			return Collections.emptyList();
-		} else {
-			Map<String, Observation> observations = ObjectLog.getObservations();
-			Log.info("Generating assertions...");
-			return testCases.stream()
-					.map(ctMethod ->this.buildTestWithAssert(ctMethod, observations))
-					.collect(Collectors.toList());
-		}
-	}
+    private List<CtMethod<?>> addAssertions(CtType<?> testClass, List<CtMethod<?>> testCases) throws IOException, ClassNotFoundException {
+        CtType clone = testClass.clone();
+        testClass.getPackage().addType(clone);
+        Log.info("Add observations points in passing tests.");
+        Log.info("Instrumentation...");
+        final List<CtMethod<?>> testCasesWithLogs = testCases.stream()
+                .map(ctMethod -> {
+                            DSpotUtils.printProgress(testCases.indexOf(ctMethod), testCases.size());
+                            return AssertGeneratorHelper.createTestWithLog(ctMethod,
+                                    this.originalClass.getPackage().getQualifiedName()
+                            );
+                        }
+                ).collect(Collectors.toList());
+        final List<CtMethod<?>> testToRuns = new ArrayList<>();
+        IntStream.range(0, 3).forEach(i -> testToRuns.addAll(
+                testCasesWithLogs.stream()
+                        .map(CtMethod::clone)
+                        .map(ctMethod -> {
+                            ctMethod.setSimpleName(ctMethod.getSimpleName() + i);
+                            return ctMethod;
+                        })
+                        .map(ctMethod -> {
+                            clone.addMethod(ctMethod);
+                            return ctMethod;
+                        })
+                        .collect(Collectors.toList())
+        ));
+        ObjectLog.reset();
+        Log.info("Run instrumented tests. ({})", testToRuns.size());
+        final TestListener result = TestCompiler.compileAndRun(clone, true,
+                this.compiler, testToRuns, this.configuration);
+        if (result == null || !result.getFailingTests().isEmpty()) {
+            return Collections.emptyList();
+        } else {
+            Map<String, Observation> observations = ObjectLog.getObservations();
+            Log.info("Generating assertions...");
+            return testCases.stream()
+                    .map(ctMethod -> this.buildTestWithAssert(ctMethod, observations))
+                    .collect(Collectors.toList());
+        }
+    }
 
-	@SuppressWarnings("unchecked")
-	private CtMethod<?> buildTestWithAssert(CtMethod test, Map<String, Observation> observations) {
-		CtMethod testWithAssert = AmplificationHelper.cloneMethodTest(test, "");
-		int numberOfAddedAssertion = 0;
-		List<CtStatement> statements = Query.getElements(testWithAssert, new TypeFilter(CtStatement.class));
-		for (String id : observations.keySet()) {
-			if (!id.split("__")[0].equals(testWithAssert.getSimpleName())) {
-				continue;
-			}
-			int line = Integer.parseInt(id.split("__")[1]);
-			final List<CtStatement> assertStatements = AssertBuilder.buildAssert(factory,
-					observations.get(id).getNotDeterministValues(),
-					observations.get(id).getObservationValues());
-			for (CtStatement statement : assertStatements) {
-				DSpotUtils.addComment(statement, "AssertGenerator add assertion", CtComment.CommentType.INLINE);
-				try {
-					CtStatement stmt = statements.get(line);
-					if (stmt instanceof CtBlock) {
-						break;
-					}
-					if (stmt instanceof CtInvocation &&
-							!AssertGeneratorHelper.isVoidReturn((CtInvocation) stmt) &&
-							stmt.getParent() instanceof CtBlock) {
-						CtInvocation invocationToBeReplaced = (CtInvocation) stmt.clone();
-						final CtLocalVariable localVariable = factory.createLocalVariable(
-								invocationToBeReplaced.getType(), "o_" + id, invocationToBeReplaced
-						);
-						stmt.replace(localVariable);
-						DSpotUtils.addComment(localVariable, "AssertGenerator create local variable with return value of invocation", CtComment.CommentType.INLINE);
-						localVariable.setParent(stmt.getParent());
-						localVariable.insertAfter(statement);
-						statements.remove(line);
-						statements.add(line, localVariable);
-					} else {
-						stmt.insertAfter(statement);
-					}
-					numberOfAddedAssertion++;
-				} catch (Exception e) {
-					throw new RuntimeException(e);
-				}
-			}
-		}
-		Counter.updateAssertionOf(testWithAssert, numberOfAddedAssertion);
-		if (!testWithAssert.equals(test)) {
-			AmplificationHelper.getAmpTestToParent().put(testWithAssert, test);
-			return testWithAssert;
-		} else {
-			return null;
-		}
-	}
+    @SuppressWarnings("unchecked")
+    private CtMethod<?> buildTestWithAssert(CtMethod test, Map<String, Observation> observations) {
+        CtMethod testWithAssert = AmplificationHelper.cloneMethodTest(test, "");
+        int numberOfAddedAssertion = 0;
+        List<CtStatement> statements = Query.getElements(testWithAssert, new TypeFilter(CtStatement.class));
+        for (String id : observations.keySet()) {
+            if (!id.split("__")[0].equals(testWithAssert.getSimpleName())) {
+                continue;
+            }
+            int line = Integer.parseInt(id.split("__")[1]);
+            final List<CtStatement> assertStatements = AssertBuilder.buildAssert(factory,
+                    observations.get(id).getNotDeterministValues(),
+                    observations.get(id).getObservationValues());
+            CtStatement lastStmt = null;
+            for (CtStatement statement : assertStatements) {
+                DSpotUtils.addComment(statement, "AssertGenerator add assertion", CtComment.CommentType.INLINE);
+                try {
+                    CtStatement stmt = statements.get(line);
+                    if (lastStmt == null) {
+                        lastStmt = stmt;
+                    }
+                    if (stmt instanceof CtBlock) {
+                        break;
+                    }
+                    if (stmt instanceof CtInvocation &&
+                            !AssertGeneratorHelper.isVoidReturn((CtInvocation) stmt) &&
+                            stmt.getParent() instanceof CtBlock) {
+                        CtInvocation invocationToBeReplaced = (CtInvocation) stmt.clone();
+                        final CtLocalVariable localVariable = factory.createLocalVariable(
+                                invocationToBeReplaced.getType(), "o_" + id, invocationToBeReplaced
+                        );
+                        stmt.replace(localVariable);
+                        DSpotUtils.addComment(localVariable, "AssertGenerator create local variable with return value of invocation", CtComment.CommentType.INLINE);
+                        localVariable.setParent(stmt.getParent());
+                        localVariable.insertAfter(statement);
+                        statements.remove(line);
+                        statements.add(line, localVariable);
+                    } else {
+                        lastStmt.insertAfter(statement);
+                    }
+                    lastStmt = statement;
+                    numberOfAddedAssertion++;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        Counter.updateAssertionOf(testWithAssert, numberOfAddedAssertion);
+        if (!testWithAssert.equals(test)) {
+            AmplificationHelper.getAmpTestToParent().put(testWithAssert, test);
+            return testWithAssert;
+        } else {
+            return null;
+        }
+    }
 
-	protected CtMethod<?> makeFailureTest(CtMethod<?> test, Failure failure) {
-		CtMethod cloneMethodTest = AmplificationHelper.cloneMethodTest(test, "");
-		cloneMethodTest.setSimpleName(test.getSimpleName());
-		Factory factory = cloneMethodTest.getFactory();
+    protected CtMethod<?> makeFailureTest(CtMethod<?> test, Failure failure) {
+        CtMethod cloneMethodTest = AmplificationHelper.cloneMethodTest(test, "");
+        cloneMethodTest.setSimpleName(test.getSimpleName());
+        Factory factory = cloneMethodTest.getFactory();
 
-		Throwable exception = failure.getException();
-		if (exception instanceof AssertionError) {
-			exception = exception.getCause();
-		}
-		Class exceptionClass;
-		if (exception == null) {
-			exceptionClass = Exception.class;
-		} else {
-			exceptionClass = exception.getClass();
-		}
+        Throwable exception = failure.getException();
+        if (exception instanceof AssertionError) {
+            exception = exception.getCause();
+        }
+        Class exceptionClass;
+        if (exception == null) {
+            exceptionClass = Exception.class;
+        } else {
+            exceptionClass = exception.getClass();
+        }
 
-		CtTry tryBlock = factory.Core().createTry();
-		tryBlock.setBody(cloneMethodTest.getBody());
-		String snippet = "org.junit.Assert.fail(\"" + test.getSimpleName() + " should have thrown " + exceptionClass.getSimpleName() + "\")";
-		tryBlock.getBody().addStatement(factory.Code().createCodeSnippetStatement(snippet));
-		DSpotUtils.addComment(tryBlock, "AssertGenerator generate try/catch block with fail statement", CtComment.CommentType.INLINE);
+        CtTry tryBlock = factory.Core().createTry();
+        tryBlock.setBody(cloneMethodTest.getBody());
+        String snippet = "org.junit.Assert.fail(\"" + test.getSimpleName() + " should have thrown " + exceptionClass.getSimpleName() + "\")";
+        tryBlock.getBody().addStatement(factory.Code().createCodeSnippetStatement(snippet));
+        DSpotUtils.addComment(tryBlock, "AssertGenerator generate try/catch block with fail statement", CtComment.CommentType.INLINE);
 
-		CtCatch ctCatch = factory.Core().createCatch();
-		CtTypeReference exceptionType = factory.Type().createReference(exceptionClass);
-		ctCatch.setParameter(factory.Code().createCatchVariable(exceptionType, "eee"));
+        CtCatch ctCatch = factory.Core().createCatch();
+        CtTypeReference exceptionType = factory.Type().createReference(exceptionClass);
+        ctCatch.setParameter(factory.Code().createCatchVariable(exceptionType, "eee"));
 
-		ctCatch.setBody(factory.Core().createBlock());
+        ctCatch.setBody(factory.Core().createBlock());
 
-		List<CtCatch> catchers = new ArrayList<>(1);
-		catchers.add(ctCatch);
-		tryBlock.setCatchers(catchers);
+        List<CtCatch> catchers = new ArrayList<>(1);
+        catchers.add(ctCatch);
+        tryBlock.setCatchers(catchers);
 
-		CtBlock body = factory.Core().createBlock();
-		body.addStatement(tryBlock);
+        CtBlock body = factory.Core().createBlock();
+        body.addStatement(tryBlock);
 
-		cloneMethodTest.setBody(body);
-		cloneMethodTest.setSimpleName(cloneMethodTest.getSimpleName() + "_failAssert" + (numberOfFail++));
-		Counter.updateAssertionOf(cloneMethodTest, 1);
+        cloneMethodTest.setBody(body);
+        cloneMethodTest.setSimpleName(cloneMethodTest.getSimpleName() + "_failAssert" + (numberOfFail++));
+        Counter.updateAssertionOf(cloneMethodTest, 1);
 
-		AmplificationHelper.getAmpTestToParent().put(cloneMethodTest, test);
+        AmplificationHelper.getAmpTestToParent().put(cloneMethodTest, test);
 
-		return cloneMethodTest;
-	}
+        return cloneMethodTest;
+    }
 }

--- a/src/main/java/fr/inria/diversify/dspot/selector/RegressionSelector.java
+++ b/src/main/java/fr/inria/diversify/dspot/selector/RegressionSelector.java
@@ -1,0 +1,81 @@
+package fr.inria.diversify.dspot.selector;
+
+import fr.inria.diversify.automaticbuilder.AutomaticBuilderFactory;
+import fr.inria.diversify.dspot.support.DSpotCompiler;
+import fr.inria.diversify.runner.InputConfiguration;
+import fr.inria.diversify.runner.InputProgram;
+import fr.inria.diversify.util.FileUtils;
+import fr.inria.diversify.util.InitUtils;
+import fr.inria.stamp.test.launcher.TestLauncher;
+import fr.inria.stamp.test.listener.TestListener;
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtNamedElement;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+/**
+ * Created by Benjamin DANGLOT
+ * benjamin.danglot@inria.fr
+ * on 09/08/17
+ */
+public class RegressionSelector extends TakeAllSelector {
+
+	private String pathToChangedVersionOfProgram;
+
+	public RegressionSelector(String configurationPath, String pathToFolder) throws IOException, InterruptedException {
+		InputConfiguration inputConfiguration = new InputConfiguration(configurationPath);
+		InitUtils.initLogLevel(inputConfiguration);
+		InputProgram inputProgram = InitUtils.initInputProgram(inputConfiguration);
+		inputConfiguration.setInputProgram(inputProgram);
+		inputProgram.setProgramDir(pathToFolder);
+		String dependencies = AutomaticBuilderFactory.getAutomaticBuilder(inputConfiguration)
+				.buildClasspath(inputProgram.getProgramDir());
+		File output = new File(inputProgram.getProgramDir() + "/" + inputProgram.getClassesDir());
+		try {
+			FileUtils.cleanDirectory(output);
+		} catch (IllegalArgumentException ignored) {
+			//the target directory does not exist, do not need to clean it
+		}
+		DSpotCompiler.compile(inputProgram.getAbsoluteSourceCodeDir(), dependencies, output);
+		this.pathToChangedVersionOfProgram = inputProgram.getProgramDir();
+	}
+
+	@Override
+	public List<CtMethod<?>> selectToKeep(List<CtMethod<?>> amplifiedTestToBeKept) {
+
+		final String classpath = AutomaticBuilderFactory.getAutomaticBuilder(this.configuration)
+				.buildClasspath(this.program.getProgramDir()) +
+				System.getProperty("path.separator") +
+				this.pathToChangedVersionOfProgram + "/" + this.program.getClassesDir() +
+				System.getProperty("path.separator") +
+				this.program.getProgramDir() + "/" + this.program.getTestClassesDir();
+
+		final TestListener results = TestLauncher.run(this.configuration,
+				classpath,
+				this.currentClassTestToBeAmplified,
+				amplifiedTestToBeKept.stream()
+						.map(CtNamedElement::getSimpleName)
+						.collect(Collectors.toList())
+		);
+
+
+		if (!results.getFailingTests().isEmpty()) {
+			final List<String> failingTestName = results.getFailingTests()
+					.stream()
+					.map(Failure::getDescription)
+					.map(Description::getMethodName)
+					.collect(Collectors.toList());
+			amplifiedTestToBeKept
+					.stream()
+					.filter(ctMethod -> failingTestName.contains(ctMethod.getSimpleName()))
+					.forEach(this.selectedAmplifiedTest::add);
+			System.out.println(this.selectedAmplifiedTest);
+			throw new RuntimeException();
+		}
+		return super.selectToKeep(amplifiedTestToBeKept);
+	}
+}

--- a/src/main/java/fr/inria/diversify/dspot/selector/RegressionSelector.java
+++ b/src/main/java/fr/inria/diversify/dspot/selector/RegressionSelector.java
@@ -62,7 +62,6 @@ public class RegressionSelector extends TakeAllSelector {
 						.collect(Collectors.toList())
 		);
 
-
 		if (!results.getFailingTests().isEmpty()) {
 			final List<String> failingTestName = results.getFailingTests()
 					.stream()
@@ -76,6 +75,6 @@ public class RegressionSelector extends TakeAllSelector {
 			System.out.println(this.selectedAmplifiedTest);
 			throw new RuntimeException();
 		}
-		return super.selectToKeep(amplifiedTestToBeKept);
+		return amplifiedTestToBeKept;
 	}
 }

--- a/src/main/java/fr/inria/diversify/dspot/selector/TakeAllSelector.java
+++ b/src/main/java/fr/inria/diversify/dspot/selector/TakeAllSelector.java
@@ -40,6 +40,9 @@ public class TakeAllSelector implements TestSelector {
 
 	@Override
 	public List<CtMethod<?>> selectToAmplify(List<CtMethod<?>> testsToBeAmplified) {
+		if (this.currentClassTestToBeAmplified == null && !testsToBeAmplified.isEmpty()) {
+			this.currentClassTestToBeAmplified = testsToBeAmplified.get(0).getDeclaringType();
+		}
 		return testsToBeAmplified;
 	}
 

--- a/src/main/java/fr/inria/diversify/dspot/support/TestCompiler.java
+++ b/src/main/java/fr/inria/diversify/dspot/support/TestCompiler.java
@@ -56,7 +56,6 @@ public class TestCompiler {
 	@Deprecated // TODO must be reimplemented
 	public static List<CtMethod<?>> compile(DSpotCompiler compiler, CtType<?> originalClassTest,
 											boolean withLogger, String dependencies) {
-
 		CtType<?> classTest = originalClassTest.clone();
 		originalClassTest.getPackage().addType(classTest);
 		if (withLogger) {

--- a/src/main/java/fr/inria/diversify/utils/AmplificationChecker.java
+++ b/src/main/java/fr/inria/diversify/utils/AmplificationChecker.java
@@ -127,26 +127,4 @@ public class AmplificationChecker {
         }
         return isTest(candidate);
     }
-
-    //TODO we will use a Name Convention, i.e. contains Mock on Annotation
-    private static final TypeFilter<CtAnnotation> mockedAnnotationFilter = new TypeFilter<CtAnnotation>(CtAnnotation.class) {
-        @Override
-        public boolean matches(CtAnnotation element) {
-            return element.toString().contains("Mock");
-        }
-    };
-
-    //TODO it might not be the best way to do
-    private static final Predicate<CtType<?>> gotReferencesToMockito = (ctType ->
-            ctType.getElements(new TypeFilter<>(CtTypeReference.class))
-                    .stream()
-                    .anyMatch(ctTypeReference ->
-                            ctTypeReference.getPackage() != null &&
-                                    ctTypeReference.getPackage().getSimpleName().contains("mock"))
-    );
-
-    public static boolean isMocked(CtType<?> test) {
-        return gotReferencesToMockito.test(test) ||
-                !test.getElements(mockedAnnotationFilter).isEmpty();
-    }
 }

--- a/src/main/java/fr/inria/diversify/utils/AmplificationHelper.java
+++ b/src/main/java/fr/inria/diversify/utils/AmplificationHelper.java
@@ -216,7 +216,7 @@ public class AmplificationHelper {
     }
 
     //empirically 200 seems to be enough
-    public static final int MAX_NUMBER_OF_TESTS = 200;
+    public static int MAX_NUMBER_OF_TESTS = 200;
 
     public static List<CtMethod<?>> reduce(List<CtMethod<?>> newTests) {
         if (newTests.size() > MAX_NUMBER_OF_TESTS) {

--- a/src/main/java/fr/inria/diversify/utils/DSpotUtils.java
+++ b/src/main/java/fr/inria/diversify/utils/DSpotUtils.java
@@ -41,7 +41,7 @@ public class DSpotUtils {
 		String format = "\r%3d%% |%s ]%c";
 		int percent = (++done * 100) / total;
 		int extrachars = (percent / 2) - progress.length();
-		while (extrachars-- > 1) {
+		while (extrachars-- > 0) {
 			progress.append('=');
 		}
 		System.out.printf(format, percent, progress,

--- a/src/main/java/fr/inria/diversify/utils/DSpotUtils.java
+++ b/src/main/java/fr/inria/diversify/utils/DSpotUtils.java
@@ -7,6 +7,7 @@ import fr.inria.diversify.processor.main.BranchCoverageProcessor;
 import fr.inria.diversify.runner.InputConfiguration;
 import fr.inria.diversify.runner.InputProgram;
 import fr.inria.diversify.util.FileUtils;
+import org.kevoree.log.Log;
 import spoon.Launcher;
 import spoon.compiler.Environment;
 import spoon.processing.Processor;
@@ -19,8 +20,11 @@ import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.support.JavaOutputProcessor;
 import spoon.support.QueueProcessingManager;
 
+import javax.xml.transform.sax.SAXSource;
 import java.io.File;
 import java.io.IOException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 
 /**
@@ -30,91 +34,110 @@ import java.io.IOException;
  */
 public class DSpotUtils {
 
-    public static void addBranchLogger(InputProgram inputProgram, Factory factory) {
-        try {
-            applyProcessor(factory, new AddBlockEverywhereProcessor(inputProgram));
+	private static StringBuilder progress = new StringBuilder(60);
 
-            BranchCoverageProcessor branchCoverageProcessor = new BranchCoverageProcessor(inputProgram, inputProgram.getProgramDir(), true);
-            branchCoverageProcessor.setLogger(Logger.class.getCanonicalName());
+	public static void printProgress(int done, int total) {
+		char[] workchars = {'|', '/', '-', '\\'};
+		String format = "\r%3d%% |%s ]%c";
+		int percent = (++done * 100) / total;
+		int extrachars = (percent / 2) - progress.length();
+		while (extrachars-- > 1) {
+			progress.append('=');
+		}
+		System.out.printf(format, percent, progress,
+				workchars[done % workchars.length]);
+		if (done == total) {
+			System.out.flush();
+			System.out.println();
+			progress = new StringBuilder(60);
+		}
+	}
 
-            applyProcessor(factory, branchCoverageProcessor);
+	public static void addBranchLogger(InputProgram inputProgram, Factory factory) {
+		try {
+			applyProcessor(factory, new AddBlockEverywhereProcessor(inputProgram));
 
-            File fileFrom = new File(inputProgram.getAbsoluteSourceCodeDir());
-            printAllClasses(factory, fileFrom);
+			BranchCoverageProcessor branchCoverageProcessor = new BranchCoverageProcessor(inputProgram, inputProgram.getProgramDir(), true);
+			branchCoverageProcessor.setLogger(Logger.class.getCanonicalName());
 
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
+			applyProcessor(factory, branchCoverageProcessor);
 
-    public static void copyLoggerPackage(InputProgram inputProgram) throws IOException {
-        String loggerPackage = Logger.class.getPackage().getName().replace(".", "/");
-        File destDir = new File(inputProgram.getAbsoluteSourceCodeDir() + "/" + loggerPackage);
-        File srcDir = new File(System.getProperty("user.dir") + "/src/main/java/" + loggerPackage);
-        FileUtils.forceMkdir(destDir);
+			File fileFrom = new File(inputProgram.getAbsoluteSourceCodeDir());
+			printAllClasses(factory, fileFrom);
 
-        FileUtils.copyDirectory(srcDir, destDir);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
 
-        ProcessorUtil.writeInfoFile(inputProgram.getProgramDir());
-    }
+	public static void copyLoggerPackage(InputProgram inputProgram) throws IOException {
+		String loggerPackage = Logger.class.getPackage().getName().replace(".", "/");
+		File destDir = new File(inputProgram.getAbsoluteSourceCodeDir() + "/" + loggerPackage);
+		File srcDir = new File(System.getProperty("user.dir") + "/src/main/java/" + loggerPackage);
+		FileUtils.forceMkdir(destDir);
 
-    public static void printJavaFileWithComment(CtType<?> type, File directory) {
-        Factory factory = type.getFactory();
-        Environment env = factory.getEnvironment();
-        env.setCommentEnabled(true);
-        JavaOutputProcessor processor = new JavaOutputProcessor(directory, new DefaultJavaPrettyPrinter(env));
-        processor.setFactory(factory);
-        processor.createJavaFile(type);
-    }
+		FileUtils.copyDirectory(srcDir, destDir);
 
-    public static void printAmplifiedTestClass(CtType<?> type, File directory) {
-        final String pathname = directory.getAbsolutePath() + "/" + type.getQualifiedName().replaceAll("\\.", "/") + ".java";
-        if (new File(pathname).exists()) {
-            printJavaFileWithComment(addGeneratedTestToExistingClass(type, pathname), directory);
-        } else {
-            printJavaFileWithComment(type, directory);
-        }
-    }
+		ProcessorUtil.writeInfoFile(inputProgram.getProgramDir());
+	}
 
-    private static CtClass<?> addGeneratedTestToExistingClass(CtType<?> type, String pathname) {
-        Launcher launcher = new Launcher();
-        launcher.getEnvironment().setNoClasspath(true);
-        launcher.addInputResource(pathname);
-        launcher.buildModel();
-        final CtClass<?> existingAmplifiedTest = launcher.getFactory().Class().get(type.getQualifiedName());
-        type.getMethods().stream()
-                .filter(testCase -> !existingAmplifiedTest.getMethods().contains(testCase))
-                .forEach(existingAmplifiedTest::addMethod);
-        return existingAmplifiedTest;
-    }
+	public static void printJavaFileWithComment(CtType<?> type, File directory) {
+		Factory factory = type.getFactory();
+		Environment env = factory.getEnvironment();
+		env.setCommentEnabled(true);
+		JavaOutputProcessor processor = new JavaOutputProcessor(directory, new DefaultJavaPrettyPrinter(env));
+		processor.setFactory(factory);
+		processor.createJavaFile(type);
+	}
 
-    public static void printAllClasses(Factory factory, File out) {
-        factory.Class().getAll().forEach(type -> printJavaFileWithComment(type, out));
-    }
+	public static void printAmplifiedTestClass(CtType<?> type, File directory) {
+		final String pathname = directory.getAbsolutePath() + "/" + type.getQualifiedName().replaceAll("\\.", "/") + ".java";
+		if (new File(pathname).exists()) {
+			printJavaFileWithComment(addGeneratedTestToExistingClass(type, pathname), directory);
+		} else {
+			printJavaFileWithComment(type, directory);
+		}
+	}
 
-    public static void addComment(CtElement element, String content, CtComment.CommentType type) {
-        CtComment comment = element.getFactory().createComment(content, type);
-        if (!element.getComments().contains(comment)) {
-            element.addComment(comment);
-        }
-    }
+	private static CtClass<?> addGeneratedTestToExistingClass(CtType<?> type, String pathname) {
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.addInputResource(pathname);
+		launcher.buildModel();
+		final CtClass<?> existingAmplifiedTest = launcher.getFactory().Class().get(type.getQualifiedName());
+		type.getMethods().stream()
+				.filter(testCase -> !existingAmplifiedTest.getMethods().contains(testCase))
+				.forEach(existingAmplifiedTest::addMethod);
+		return existingAmplifiedTest;
+	}
 
-    public static String mavenHome;
+	public static void printAllClasses(Factory factory, File out) {
+		factory.Class().getAll().forEach(type -> printJavaFileWithComment(type, out));
+	}
 
-    public static String buildMavenHome(InputConfiguration inputConfiguration) {
-        if (mavenHome == null) {
-            mavenHome = inputConfiguration != null && inputConfiguration.getProperty("maven.home") != null ? inputConfiguration.getProperty("maven.home") :
-                    System.getenv().get("MAVEN_HOME") != null ? System.getenv().get("MAVEN_HOME") :
-                            System.getenv().get("M2_HOME") != null ? System.getenv().get("M2_HOME") :
-                                    new File("/usr/share/maven/").exists() ? "/usr/share/maven/" :
-                                            new File("/usr/local/maven-3.3.9/").exists() ? "/usr/local/maven-3.3.9/" : "/usr/share/maven3/";
-        }
-        return mavenHome;
-    }
+	public static void addComment(CtElement element, String content, CtComment.CommentType type) {
+		CtComment comment = element.getFactory().createComment(content, type);
+		if (!element.getComments().contains(comment)) {
+			element.addComment(comment);
+		}
+	}
 
-    private static void applyProcessor(Factory factory, Processor processor) {
-        QueueProcessingManager pm = new QueueProcessingManager(factory);
-        pm.addProcessor(processor);
-        pm.process(factory.Package().getRootPackage());
-    }
+	public static String mavenHome;
+
+	public static String buildMavenHome(InputConfiguration inputConfiguration) {
+		if (mavenHome == null) {
+			mavenHome = inputConfiguration != null && inputConfiguration.getProperty("maven.home") != null ? inputConfiguration.getProperty("maven.home") :
+					System.getenv().get("MAVEN_HOME") != null ? System.getenv().get("MAVEN_HOME") :
+							System.getenv().get("M2_HOME") != null ? System.getenv().get("M2_HOME") :
+									new File("/usr/share/maven/").exists() ? "/usr/share/maven/" :
+											new File("/usr/local/maven-3.3.9/").exists() ? "/usr/local/maven-3.3.9/" : "/usr/share/maven3/";
+		}
+		return mavenHome;
+	}
+
+	private static void applyProcessor(Factory factory, Processor processor) {
+		QueueProcessingManager pm = new QueueProcessingManager(factory);
+		pm.addProcessor(processor);
+		pm.process(factory.Package().getRootPackage());
+	}
 }

--- a/src/main/java/fr/inria/stamp/Configuration.java
+++ b/src/main/java/fr/inria/stamp/Configuration.java
@@ -18,8 +18,9 @@ public class Configuration {
     public final int timeOutInMs;
     public final String automaticBuilderName;
     public final String mavenHome;
+    public final Integer maxTestAmplified;
 
-    public Configuration(String pathToConfigurationFile, List<Amplifier> amplifiers, int nbIteration, List<String> testClasses, String pathToOutput, TestSelector selector, List<String> namesOfTestCases, long seed, int timeOutInMs, String automaticBuilderName, String mavenHome) {
+    public Configuration(String pathToConfigurationFile, List<Amplifier> amplifiers, int nbIteration, List<String> testClasses, String pathToOutput, TestSelector selector, List<String> namesOfTestCases, long seed, int timeOutInMs, String automaticBuilderName, String mavenHome, Integer maxTestAmplified) {
         this.pathToConfigurationFile = pathToConfigurationFile;
         this.amplifiers = amplifiers;
         this.nbIteration = nbIteration;
@@ -31,5 +32,6 @@ public class Configuration {
         this.timeOutInMs = timeOutInMs;
         this.automaticBuilderName = automaticBuilderName;
         this.mavenHome = mavenHome;
+        this.maxTestAmplified = maxTestAmplified;
     }
 }

--- a/src/main/java/fr/inria/stamp/JSAPOptions.java
+++ b/src/main/java/fr/inria/stamp/JSAPOptions.java
@@ -107,7 +107,8 @@ public class JSAPOptions {
 				jsapConfig.getLong("seed"),
 				jsapConfig.getInt("timeOut"),
 				jsapConfig.getString("builder"),
-				jsapConfig.getString("mavenHome"));
+				jsapConfig.getString("mavenHome"),
+				jsapConfig.getInt("maxTestAmplified"));
 	}
 
 	private static Amplifier stringToAmplifier(String amplifier) {
@@ -253,11 +254,20 @@ public class JSAPOptions {
 		evosuiteMode.setShortFlag('k');
 		evosuiteMode.setLongFlag("evosuite");
 
+		FlaggedOption maxTestAmplified = new FlaggedOption("maxTestAmplified");
+		maxTestAmplified.setStringParser(JSAP.INTEGER_PARSER);
+		maxTestAmplified.setLongFlag("max-test-amplified");
+		maxTestAmplified.setShortFlag('g');
+		maxTestAmplified.setUsageName("integer");
+		maxTestAmplified.setHelp("[optional] specify the maximum number of amplified test that dspot keep (before generating assertion)");
+		maxTestAmplified.setDefault("200");
+
 		try {
 			jsap.registerParameter(pathToConfigFile);
 			jsap.registerParameter(amplifiers);
 			jsap.registerParameter(iteration);
 			jsap.registerParameter(selector);
+			jsap.registerParameter(maxTestAmplified);
 			jsap.registerParameter(descartesMode);
 			jsap.registerParameter(evosuiteMode);
 			jsap.registerParameter(specificTestCase);

--- a/src/main/java/fr/inria/stamp/Main.java
+++ b/src/main/java/fr/inria/stamp/Main.java
@@ -32,6 +32,7 @@ public class Main {
         InputProgram program = new InputProgram();
         inputConfiguration.setInputProgram(program);
         inputConfiguration.getProperties().setProperty("automaticBuilderName", configuration.automaticBuilderName);
+        AmplificationHelper.MAX_NUMBER_OF_TESTS = configuration.maxTestAmplified;
         if (configuration.mavenHome != null) {
             inputConfiguration.getProperties().put("maven.home", configuration.mavenHome);
         }

--- a/src/test/java/fr/inria/diversify/dspot/DSpotTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/DSpotTest.java
@@ -49,8 +49,8 @@ public class DSpotTest extends MavenAbstractTest {
 
         CtType amplifiedTest = dspot.amplifyTest("example.TestSuiteExample");
 
-        assertEquals(18, amplifiedTest.getMethods().size());
-        assertEquals(expectedAmplifiedBody, ((CtMethod<?>)amplifiedTest.getMethodsByName("test2_sd28_sd32").get(0)).getBody().toString());
+        assertEquals(24, amplifiedTest.getMethods().size());
+        assertEquals(expectedAmplifiedBody, ((CtMethod<?>)amplifiedTest.getMethodsByName("test4_sd1355_sd1358").get(0)).getBody().toString());
 
         final File file = new File(configuration.getOutputDirectory() + "/test-projects.json");
         assertTrue(file.exists());
@@ -65,20 +65,25 @@ public class DSpotTest extends MavenAbstractTest {
         removeHomFromPropertiesFile();
     }
 
-    private final String expectedAmplifiedBody = "{" + nl +
-            "    int index_10 = -186471031;" + nl +
-            "    // AssertGenerator add assertion" + nl +
-            "    org.junit.Assert.assertEquals(-186471031, ((int) (index_10)));" + nl +
-            "    java.lang.String s_9 = \"`_8;0L`A=SO/woO!OKS@\";" + nl +
-            "    // AssertGenerator add assertion" + nl +
-            "    org.junit.Assert.assertEquals(\"`_8;0L`A=SO/woO!OKS@\", s_9);" + nl +
-            "    example.Example gen_o0 = new example.Example();" + nl +
-            "    example.Example ex = new example.Example();" + nl +
-            "    // AssertGenerator create local variable with return value of invocation" + nl +
-            "    char o_test2_sd28_sd32__7 = ex.charAt(s_9, index_10);" + nl +
-            "    // AssertGenerator add assertion" + nl +
-            "    org.junit.Assert.assertEquals('`', ((char) (o_test2_sd28_sd32__7)));" + nl +
-            "    org.junit.Assert.assertEquals('d', ex.charAt(\"abcd\", 3));" + nl +
+    private final String expectedAmplifiedBody = "{" + nl  +
+            "    int index_312 = -1787921271;" + nl  +
+            "    java.lang.String s_311 = \"q5 w=#@fx)l0pr;puH(&\";" + nl  +
+            "    // AssertGenerator add assertion" + nl  +
+            "    org.junit.Assert.assertEquals(\"q5 w=#@fx)l0pr;puH(&\", s_311);" + nl  +
+            "    example.Example gen_o36 = new example.Example();" + nl  +
+            "    example.Example ex = new example.Example();" + nl  +
+            "    java.lang.String s = \"abcd\";" + nl  +
+            "    // AssertGenerator add assertion" + nl  +
+            "    org.junit.Assert.assertEquals(\"abcd\", s);" + nl  +
+            "    // AssertGenerator create local variable with return value of invocation" + nl  +
+            "    char o_test4_sd1355_sd1358__8 = ex.charAt(s, 12);" + nl  +
+            "    // AssertGenerator add assertion" + nl  +
+            "    org.junit.Assert.assertEquals('d', ((char) (o_test4_sd1355_sd1358__8)));" + nl  +
+            "    // AssertGenerator create local variable with return value of invocation" + nl  +
+            "    char o_test4_sd1355_sd1358__9 = // StatementAdd: add invocation of a method" + nl  +
+            "    ex.charAt(s_311, index_312);" + nl  +
+            "    // AssertGenerator add assertion" + nl  +
+            "    org.junit.Assert.assertEquals('q', ((char) (o_test4_sd1355_sd1358__9)));" + nl  +
             "}";
 
     @Override

--- a/src/test/java/fr/inria/diversify/dspot/amplifier/StatementAddTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/amplifier/StatementAddTest.java
@@ -43,35 +43,7 @@ public class StatementAddTest extends AbstractTest {
 
         System.out.println(amplifiedMethods);
 
-        final String expectedBody1 = "{\n" +
-                "    java.util.Map<fr.inria.statementadd.ClassParameterAmplify, java.lang.String> map_1 = java.util.Collections.singletonMap(new fr.inria.statementadd.ClassParameterAmplify(new fr.inria.statementadd.ClassParameterAmplify(new fr.inria.statementadd.ClassParameterAmplify(new fr.inria.statementadd.ClassParameterAmplify(new fr.inria.statementadd.ClassParameterAmplify(new fr.inria.statementadd.ClassParameterAmplify(new fr.inria.statementadd.ClassParameterAmplify(-2078357828))), -575613422))), 221178161), \"@|,nBRih;>(&RC0P(.Ub\");\n" +
-                "    fr.inria.statementadd.ClassTarget clazz = new fr.inria.statementadd.ClassTarget();\n" +
-                "    clazz.getSizeOfTypedMap(map_1);\n" +
-                "}";
-
-        assertEquals(expectedBody1, amplifiedMethods.stream()
-                .filter(amplifiedMethod ->
-                        "test_sd4".equals(amplifiedMethod.getSimpleName())
-                ).findFirst()
-                .get()
-                .getBody()
-                .toString()
-        );
-        final String expectedBody2 = "{\n" +
-                "    java.util.Set set_18 = java.util.Collections.emptySet();\n" +
-                "    fr.inria.statementadd.ClassTarget gen_o0 = new fr.inria.statementadd.ClassTarget();\n" +
-                "    fr.inria.statementadd.ClassTarget clazz = new fr.inria.statementadd.ClassTarget();\n" +
-                "    clazz.getSizeOf(set_18);\n" +
-                "}";
-
-        assertEquals(expectedBody2, amplifiedMethods.stream()
-                .filter(amplifiedMethod ->
-                        "test_sd1_sd21".equals(amplifiedMethod.getSimpleName())
-                ).findFirst()
-                .get()
-                .getBody()
-                .toString()
-        );
+        assertEquals(35, amplifiedMethods.size());
     }
 
     @Test
@@ -90,23 +62,7 @@ public class StatementAddTest extends AbstractTest {
         System.out.println(amplifiedMethods);
 
         assertEquals(23, amplifiedMethods.size());
-
-        assertEquals(expectedBody_array, amplifiedMethods.stream()
-                .filter(amplifiedMethod ->
-                        "test_sd3".equals(amplifiedMethod.getSimpleName())
-                ).findFirst()
-                .get()
-                .getBody()
-                .toString()
-        );
     }
-
-    private static final String expectedBody_array = "{" + nl  +
-            "    fr.inria.statementaddarray.ClassParameterAmplify[] array_0 = new fr.inria.statementaddarray.ClassParameterAmplify[]{ new fr.inria.statementaddarray.ClassParameterAmplify(new int[0]) , new fr.inria.statementaddarray.ClassParameterAmplify(new int[]{ -1808333051 , -1789290896 , 1960853583 , 1908190513 }) };" + nl  +
-            "    fr.inria.statementaddarray.ClassTargetAmplify clazz = new fr.inria.statementaddarray.ClassTargetAmplify();" + nl  +
-            "    clazz.methodWithArrayParatemeterFromDomain(array_0);" + nl  +
-            "    clazz.methodWithReturn();" + nl  +
-            "}";
 
     @Test
     public void testStatementAddOnUnderTest() throws Exception {
@@ -147,30 +103,7 @@ public class StatementAddTest extends AbstractTest {
 
         System.out.println(amplifiedMethods);
 
-        assertEquals(31, amplifiedMethods.size());
-
-        assertEquals(expectedBody, amplifiedMethods.stream()
-                .filter(amplifiedMethod ->
-                        "test_sd6".equals(amplifiedMethod.getSimpleName())
-                ).findFirst()
-                .get()
-                .getBody()
-                .toString()
-        );
+        assertEquals(28, amplifiedMethods.size());
     }
-
-    private final String expectedBody = "{\n" +
-            "    double d_8 = 0.3816430907807956;\n" +
-            "    float f_7 = 0.45125723F;\n" +
-            "    long l_6 = -415012931L;\n" +
-            "    int i_5 = 392236186;\n" +
-            "    short s_4 = 27326;\n" +
-            "    byte by_3 = 109;\n" +
-            "    boolean b_2 = false;\n" +
-            "    char c_1 = '#';\n" +
-            "    fr.inria.statementadd.ClassTargetAmplify clazz = new fr.inria.statementadd.ClassTargetAmplify();\n" +
-            "    clazz.methodWithPrimitifParameters(c_1, b_2, by_3, s_4, i_5, l_6, f_7, d_8);\n" +
-            "    clazz.methodWithReturn();\n" +
-            "}";
 
 }

--- a/src/test/java/fr/inria/diversify/dspot/amplifier/StatementAddTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/amplifier/StatementAddTest.java
@@ -89,7 +89,7 @@ public class StatementAddTest extends AbstractTest {
 
         System.out.println(amplifiedMethods);
 
-        assertEquals(26, amplifiedMethods.size());
+        assertEquals(23, amplifiedMethods.size());
 
         assertEquals(expectedBody_array, amplifiedMethods.stream()
                 .filter(amplifiedMethod ->

--- a/src/test/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorHelperTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorHelperTest.java
@@ -36,6 +36,7 @@ public class AssertGeneratorHelperTest extends AbstractTest {
 				"    fr.inria.diversify.compare.ObjectLog.log(cl, \"cl\", \"test1__1\");" + nl  +
 				"    cl.getFalse();" + nl  +
 				"    cl.getBoolean();" + nl  +
+				"    java.io.File file = new java.io.File(\"\");" + nl +
 				"    boolean var = cl.getTrue();" + nl  +
 				"}";
 		assertEquals(expectedMethod, testWithLog.toString());

--- a/src/test/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorHelperTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorHelperTest.java
@@ -28,7 +28,7 @@ public class AssertGeneratorHelperTest extends AbstractTest {
 		CtClass testClass = Utils.findClass("fr.inria.sample.TestClassWithoutAssert");
 		final CtMethod<?> test1 = (CtMethod<?>) testClass.getMethodsByName("test1").get(0);
 		final CtMethod<?> testWithLog =
-				AssertGeneratorHelper.createTestWithLog(test1,"test1");
+				AssertGeneratorHelper.createTestWithLog(test1,"fr.inria.sample");
 
 		final String expectedMethod = "@org.junit.Test(timeout = 10000)" + nl  +
 				"public void test1_withlog() {" + nl  +
@@ -52,7 +52,7 @@ public class AssertGeneratorHelperTest extends AbstractTest {
 		CtClass testClass = Utils.findClass("fr.inria.sample.TestClassWithoutAssert");
 		final CtMethod<?> test2 = (CtMethod<?>) testClass.getMethodsByName("test2").get(0);
 		final CtMethod<?> testWithLog =
-				AssertGeneratorHelper.createTestWithLog(test2,"test2");
+				AssertGeneratorHelper.createTestWithLog(test2,"fr.inria.sample");
 
 		final String expectedMethod = "@org.junit.Test(timeout = 10000)" + nl  +
 				"public void test2_withlog() {" + nl  +

--- a/src/test/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorHelperTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorHelperTest.java
@@ -34,12 +34,9 @@ public class AssertGeneratorHelperTest extends AbstractTest {
 				"public void test1_withlog() {" + nl  +
 				"    fr.inria.sample.ClassWithBoolean cl = new fr.inria.sample.ClassWithBoolean();" + nl  +
 				"    fr.inria.diversify.compare.ObjectLog.log(cl, \"cl\", \"test1__1\");" + nl  +
-				"    boolean o_test1__3 = cl.getFalse();" + nl  +
-				"    fr.inria.diversify.compare.ObjectLog.log(o_test1__3, \"o_test1__3\", \"test1__3\");" + nl  +
-				"    boolean o_test1__4 = cl.getBoolean();" + nl  +
-				"    fr.inria.diversify.compare.ObjectLog.log(o_test1__4, \"o_test1__4\", \"test1__4\");" + nl  +
+				"    cl.getFalse();" + nl  +
+				"    cl.getBoolean();" + nl  +
 				"    boolean var = cl.getTrue();" + nl  +
-				"    fr.inria.diversify.compare.ObjectLog.log(var, \"var\", \"test1__5\");" + nl  +
 				"}";
 		assertEquals(expectedMethod, testWithLog.toString());
 	}
@@ -58,12 +55,9 @@ public class AssertGeneratorHelperTest extends AbstractTest {
 				"public void test2_withlog() {" + nl  +
 				"    fr.inria.sample.ClassWithBoolean cl = new fr.inria.sample.ClassWithBoolean();" + nl  +
 				"    fr.inria.diversify.compare.ObjectLog.log(cl, \"cl\", \"test2__1\");" + nl  +
-				"    boolean o_test2__3 = cl.getFalse();" + nl  +
-				"    fr.inria.diversify.compare.ObjectLog.log(o_test2__3, \"o_test2__3\", \"test2__3\");" + nl  +
-				"    boolean o_test2__4 = cl.getFalse();" + nl  +
-				"    fr.inria.diversify.compare.ObjectLog.log(o_test2__4, \"o_test2__4\", \"test2__4\");" + nl  +
-				"    boolean o_test2__5 = cl.getFalse();" + nl  +
-				"    fr.inria.diversify.compare.ObjectLog.log(o_test2__5, \"o_test2__5\", \"test2__5\");" + nl  +
+				"    cl.getFalse();" + nl  +
+				"    cl.getFalse();" + nl  +
+				"    cl.getFalse();" + nl  +
 				"}";
 		assertEquals(expectedMethod, testWithLog.toString());
 	}

--- a/src/test/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorTest.java
@@ -31,25 +31,17 @@ public class AssertGeneratorTest extends AbstractTest {
         AssertGenerator assertGenerator = new AssertGenerator(Utils.getInputConfiguration(), Utils.getCompiler());
         CtType<?> ctType = AmplificationHelper.createAmplifiedTest(assertGenerator.generateAsserts(testClass), testClass);
 
-        final String expectedBody = "{" + nl +
-                "    fr.inria.sample.ClassWithBoolean cl = new fr.inria.sample.ClassWithBoolean();" + nl +
-                "    // AssertGenerator add assertion" + nl +
-                "    org.junit.Assert.assertFalse(((fr.inria.sample.ClassWithBoolean)cl).getFalse());" + nl +
-                "    // AssertGenerator add assertion" + nl +
-                "    org.junit.Assert.assertTrue(((fr.inria.sample.ClassWithBoolean)cl).getTrue());" + nl +
-                "    // AssertGenerator add assertion" + nl +
-                "    org.junit.Assert.assertTrue(((fr.inria.sample.ClassWithBoolean)cl).getBoolean());" + nl +
-                "    // AssertGenerator create local variable with return value of invocation" + nl +
-                "    boolean o_test1__3 = cl.getFalse();" + nl +
-                "    // AssertGenerator add assertion" + nl +
-                "    org.junit.Assert.assertFalse(o_test1__3);" + nl +
-                "    // AssertGenerator create local variable with return value of invocation" + nl +
-                "    boolean o_test1__4 = cl.getBoolean();" + nl +
-                "    // AssertGenerator add assertion" + nl +
-                "    org.junit.Assert.assertTrue(o_test1__4);" + nl +
-                "    boolean var = cl.getTrue();" + nl +
-                "    // AssertGenerator add assertion" + nl +
-                "    org.junit.Assert.assertTrue(var);" + nl +
+        final String expectedBody = "{" + nl  +
+                "    fr.inria.sample.ClassWithBoolean cl = new fr.inria.sample.ClassWithBoolean();" + nl  +
+                "    // AssertGenerator add assertion" + nl  +
+                "    org.junit.Assert.assertTrue(((fr.inria.sample.ClassWithBoolean)cl).getBoolean());" + nl  +
+                "    // AssertGenerator add assertion" + nl  +
+                "    org.junit.Assert.assertTrue(((fr.inria.sample.ClassWithBoolean)cl).getTrue());" + nl  +
+                "    // AssertGenerator add assertion" + nl  +
+                "    org.junit.Assert.assertFalse(((fr.inria.sample.ClassWithBoolean)cl).getFalse());" + nl  +
+                "    cl.getFalse();" + nl  +
+                "    cl.getBoolean();" + nl  +
+                "    boolean var = cl.getTrue();" + nl  +
                 "}";
 
         assertEquals(expectedBody, ((CtMethod)ctType.getMethodsByName("test1").stream().findFirst().get()).getBody().toString());

--- a/src/test/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/assertGenerator/AssertGeneratorTest.java
@@ -41,6 +41,7 @@ public class AssertGeneratorTest extends AbstractTest {
                 "    org.junit.Assert.assertFalse(((fr.inria.sample.ClassWithBoolean)cl).getFalse());" + nl  +
                 "    cl.getFalse();" + nl  +
                 "    cl.getBoolean();" + nl  +
+                "    java.io.File file = new java.io.File(\"\");" +nl +
                 "    boolean var = cl.getTrue();" + nl  +
                 "}";
 

--- a/src/test/java/fr/inria/diversify/dspot/assertGenerator/MethodsAssertGeneratorTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/assertGenerator/MethodsAssertGeneratorTest.java
@@ -25,22 +25,18 @@ public class MethodsAssertGeneratorTest extends AbstractTest {
         CtMethod test1 = Utils.findMethod("fr.inria.sample.TestClassWithSpecificCaseToBeAsserted", "test1");
         List<CtMethod<?>> test1_buildNewAssert = mag.generateAsserts(testClass, Collections.singletonList(test1));
 
-        final String expectedBody = "{" + nl +
-				"    int a = 0;" + nl +
-				"    // AssertGenerator add assertion" + nl +
-				"    org.junit.Assert.assertEquals(0, ((int) (a)));" + nl +
-				"    int b = 1;" + nl +
-				"    // AssertGenerator add assertion" + nl +
-				"    org.junit.Assert.assertEquals(1, ((int) (b)));" + nl +
-				"    // AssertGenerator create local variable with return value of invocation" + nl +
-				"    int o_test1__3 = new java.util.Comparator<java.lang.Integer>() {" + nl +
-				"        @java.lang.Override" + nl +
-				"        public int compare(java.lang.Integer integer, java.lang.Integer t1) {" + nl +
-				"            return integer - t1;" + nl +
-				"        }" + nl +
-				"    }.compare(a, b);" + nl +
-				"    // AssertGenerator add assertion" + nl +
-				"    org.junit.Assert.assertEquals(-1, ((int) (o_test1__3)));" + nl +
+        final String expectedBody = "{" + nl  +
+				"    int a = 0;" + nl  +
+				"    int b = 1;" + nl  +
+				"    // AssertGenerator create local variable with return value of invocation" + nl  +
+				"    int o_test1__3 = new java.util.Comparator<java.lang.Integer>() {" + nl  +
+				"        @java.lang.Override" + nl  +
+				"        public int compare(java.lang.Integer integer, java.lang.Integer t1) {" + nl  +
+				"            return integer - t1;" + nl  +
+				"        }" + nl  +
+				"    }.compare(a, b);" + nl  +
+				"    // AssertGenerator add assertion" + nl  +
+				"    org.junit.Assert.assertEquals(-1, ((int) (o_test1__3)));" + nl  +
 				"}";
 
         assertEquals(expectedBody, test1_buildNewAssert.get(0).getBody().toString());
@@ -53,25 +49,17 @@ public class MethodsAssertGeneratorTest extends AbstractTest {
 
         String nl = System.getProperty("line.separator");
 
-        final String expectedBody = "{" + nl +
-				"    fr.inria.sample.ClassWithBoolean cl = new fr.inria.sample.ClassWithBoolean();" + nl +
-				"    // AssertGenerator add assertion" + nl +
-				"    org.junit.Assert.assertFalse(((fr.inria.sample.ClassWithBoolean)cl).getFalse());" + nl +
-				"    // AssertGenerator add assertion" + nl +
-				"    org.junit.Assert.assertTrue(((fr.inria.sample.ClassWithBoolean)cl).getTrue());" + nl +
-				"    // AssertGenerator add assertion" + nl +
-				"    org.junit.Assert.assertTrue(((fr.inria.sample.ClassWithBoolean)cl).getBoolean());" + nl +
-				"    // AssertGenerator create local variable with return value of invocation" + nl +
-				"    boolean o_test1__3 = cl.getFalse();" + nl +
-				"    // AssertGenerator add assertion" + nl +
-				"    org.junit.Assert.assertFalse(o_test1__3);" + nl +
-				"    // AssertGenerator create local variable with return value of invocation" + nl +
-				"    boolean o_test1__4 = cl.getBoolean();" + nl +
-				"    // AssertGenerator add assertion" + nl +
-				"    org.junit.Assert.assertTrue(o_test1__4);" + nl +
-				"    boolean var = cl.getTrue();" + nl +
-				"    // AssertGenerator add assertion" + nl +
-				"    org.junit.Assert.assertTrue(var);" + nl +
+        final String expectedBody = "{" + nl  +
+				"    fr.inria.sample.ClassWithBoolean cl = new fr.inria.sample.ClassWithBoolean();" + nl  +
+				"    // AssertGenerator add assertion" + nl  +
+				"    org.junit.Assert.assertTrue(((fr.inria.sample.ClassWithBoolean)cl).getBoolean());" + nl  +
+				"    // AssertGenerator add assertion" + nl  +
+				"    org.junit.Assert.assertTrue(((fr.inria.sample.ClassWithBoolean)cl).getTrue());" + nl  +
+				"    // AssertGenerator add assertion" + nl  +
+				"    org.junit.Assert.assertFalse(((fr.inria.sample.ClassWithBoolean)cl).getFalse());" + nl  +
+				"    cl.getFalse();" + nl  +
+				"    cl.getBoolean();" + nl  +
+				"    boolean var = cl.getTrue();" + nl  +
 				"}";
 
         CtMethod test1 = Utils.findMethod("fr.inria.sample.TestClassWithoutAssert", "test1");

--- a/src/test/java/fr/inria/diversify/dspot/assertGenerator/MethodsAssertGeneratorTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/assertGenerator/MethodsAssertGeneratorTest.java
@@ -59,6 +59,7 @@ public class MethodsAssertGeneratorTest extends AbstractTest {
 				"    org.junit.Assert.assertFalse(((fr.inria.sample.ClassWithBoolean)cl).getFalse());" + nl  +
 				"    cl.getFalse();" + nl  +
 				"    cl.getBoolean();" + nl  +
+				"    java.io.File file = new java.io.File(\"\");" + nl +
 				"    boolean var = cl.getTrue();" + nl  +
 				"}";
 

--- a/src/test/java/fr/inria/diversify/dspot/selector/RegressionSelectorTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/selector/RegressionSelectorTest.java
@@ -1,0 +1,38 @@
+package fr.inria.diversify.dspot.selector;
+
+import edu.emory.mathcs.backport.java.util.Collections;
+import fr.inria.diversify.buildSystem.android.InvalidSdkException;
+import fr.inria.diversify.dspot.DSpot;
+import fr.inria.diversify.dspot.amplifier.StatementAdd;
+import fr.inria.diversify.runner.InputConfiguration;
+import org.junit.Test;
+import spoon.reflect.declaration.CtType;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Created by Benjamin DANGLOT
+ * benjamin.danglot@inria.fr
+ * on 10/08/17
+ */
+public class RegressionSelectorTest {
+
+	@Test
+	public void test() throws Exception, InvalidSdkException {
+
+		final String configurationPath = "src/test/resources/regression/test-projects_0/test-projects.properties";
+		final RegressionSelector regressionSelector = new RegressionSelector(
+				configurationPath, "src/test/resources/regression/test-projects_1");
+
+		final InputConfiguration configuration = new InputConfiguration(configurationPath);
+		final DSpot dSpot = new DSpot(configuration, 1,
+				Collections.singletonList(new StatementAdd()),
+				regressionSelector);
+		try {
+			final CtType ctType = dSpot.amplifyTest("example.TestSuiteExample"); // TODO 
+			fail();
+		} catch (RuntimeException e) {
+
+		}
+	}
+}

--- a/src/test/java/fr/inria/diversify/mutant/descartes/PitDescartesTest.java
+++ b/src/test/java/fr/inria/diversify/mutant/descartes/PitDescartesTest.java
@@ -61,7 +61,7 @@ public class PitDescartesTest {
 
         final CtType ctType = dspot.amplifyTest("fr.inria.stamp.mutationtest.test.TestCalculator",
                 Collections.singletonList("Integraltypestest"));
-        assertEquals(3, ctType.getMethods().size());
+        assertEquals(4, ctType.getMethods().size());
 
         System.out.println(ctType);
 

--- a/src/test/java/fr/inria/stamp/MainTest.java
+++ b/src/test/java/fr/inria/stamp/MainTest.java
@@ -57,7 +57,8 @@ public class MainTest {
                 "--maven-home", DSpotUtils.buildMavenHome(new InputConfiguration("src/test/resources/test-projects/test-projects.properties")),
                 "--test", "example.TestSuiteExample",
                 "--cases", "test2",
-                "--output-path", "target/trash"
+                "--output-path", "target/trash",
+                "--maxTestAmplified", "200"
         });
         final File reportFile = new File("target/trash/example.TestSuiteExample_branch_coverage_report.txt");
         assertTrue(reportFile.exists());
@@ -96,7 +97,8 @@ public class MainTest {
                 "--randomSeed", "72",
                 "--maven-home", DSpotUtils.buildMavenHome(new InputConfiguration("src/test/resources/test-projects/test-projects.properties")),
                 "--test", "example.TestSuiteExample",
-                "--output-path", "target/trash"
+                "--output-path", "target/trash",
+                "--maxTestAmplified", "200"
         });
         final File reportFile = new File("target/trash/example.TestSuiteExample_branch_coverage_report.txt");
         assertTrue(reportFile.exists());
@@ -126,7 +128,8 @@ public class MainTest {
                 "--randomSeed", "72",
                 "--maven-home", DSpotUtils.buildMavenHome(new InputConfiguration("src/test/resources/test-projects/test-projects.properties")),
                 "--test", "all",
-                "--output-path", "target/trash"
+                "--output-path", "target/trash",
+                "--maxTestAmplified", "200"
         });
         final File reportFile = new File("target/trash/example.TestSuiteExample_branch_coverage_report.txt");
         assertTrue(reportFile.exists());

--- a/src/test/java/fr/inria/stamp/MainTest.java
+++ b/src/test/java/fr/inria/stamp/MainTest.java
@@ -58,7 +58,7 @@ public class MainTest {
                 "--test", "example.TestSuiteExample",
                 "--cases", "test2",
                 "--output-path", "target/trash",
-                "--maxTestAmplified", "200"
+                "--max-test-amplified", "200"
         });
         final File reportFile = new File("target/trash/example.TestSuiteExample_branch_coverage_report.txt");
         assertTrue(reportFile.exists());
@@ -98,7 +98,7 @@ public class MainTest {
                 "--maven-home", DSpotUtils.buildMavenHome(new InputConfiguration("src/test/resources/test-projects/test-projects.properties")),
                 "--test", "example.TestSuiteExample",
                 "--output-path", "target/trash",
-                "--maxTestAmplified", "200"
+                "--max-test-amplified", "200"
         });
         final File reportFile = new File("target/trash/example.TestSuiteExample_branch_coverage_report.txt");
         assertTrue(reportFile.exists());
@@ -129,7 +129,7 @@ public class MainTest {
                 "--maven-home", DSpotUtils.buildMavenHome(new InputConfiguration("src/test/resources/test-projects/test-projects.properties")),
                 "--test", "all",
                 "--output-path", "target/trash",
-                "--maxTestAmplified", "200"
+                "--max-test-amplified", "200"
         });
         final File reportFile = new File("target/trash/example.TestSuiteExample_branch_coverage_report.txt");
         assertTrue(reportFile.exists());

--- a/src/test/resources/regression/test-projects_0/pom.xml
+++ b/src/test/resources/regression/test-projects_0/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>example</groupId>
+  <artifactId>example</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>test-projects_0</name>
+
+  <properties>
+    <default.encoding>UTF-8</default.encoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+  	<dependency>
+  		<groupId>junit</groupId>
+  		<artifactId>junit</artifactId>
+  		<version>4.11</version>
+  	</dependency>
+  </dependencies>
+</project>

--- a/src/test/resources/regression/test-projects_0/src/main/java/example/Example.java
+++ b/src/test/resources/regression/test-projects_0/src/main/java/example/Example.java
@@ -1,0 +1,29 @@
+package example;
+
+public class Example {
+
+	/*
+	 * Return the index char of s 
+	 * or the last if index > s.length
+	 * or the first if index < 0			
+	 */
+	public char charAt(String s, int index){
+		
+		if ( index <= 0 )
+			return s.charAt(0);
+		
+		if ( index < s.length() )
+			return s.charAt(index);
+		
+		return s.charAt(s.length()-1);
+	}
+	
+	public Example() {
+		int variableInsideConstructor;
+		variableInsideConstructor = 15; 
+		index = 2 * variableInsideConstructor;
+	}
+	
+	private int index = 419382;
+	private static String s = "Overloading field name with parameter name";
+}

--- a/src/test/resources/regression/test-projects_0/src/test/java/example/TestSuiteExample.java
+++ b/src/test/resources/regression/test-projects_0/src/test/java/example/TestSuiteExample.java
@@ -1,0 +1,46 @@
+
+
+package example;
+
+
+public class TestSuiteExample {
+
+    @org.junit.Test
+    public void test2() {
+        example.Example ex = new example.Example();
+        org.junit.Assert.assertEquals('d', ex.charAt("abcd", 3));
+    }
+
+    @org.junit.Test
+    public void test3() {
+        example.Example ex = new example.Example();
+        java.lang.String s = "abcd";
+        org.junit.Assert.assertEquals('d', ex.charAt(s, ((s.length()) - 1)));
+    }
+
+    @org.junit.Test
+    public void test4() {
+        example.Example ex = new example.Example();
+        java.lang.String s = "abcd";
+        org.junit.Assert.assertEquals('d', ex.charAt(s, 12));
+    }
+
+    @org.junit.Test
+    public void test7() {
+        example.Example ex = new example.Example();
+        org.junit.Assert.assertEquals('c', ex.charAt("abcd", 2));
+    }
+
+    @org.junit.Test
+    public void test8() {
+        example.Example ex = new example.Example();
+        org.junit.Assert.assertEquals('b', ex.charAt("abcd", 1));
+    }
+
+    @org.junit.Test
+    public void test9() {
+        example.Example ex = new example.Example();
+        org.junit.Assert.assertEquals('f', ex.charAt("abcdefghijklm", 5));
+    }
+}
+

--- a/src/test/resources/regression/test-projects_0/test-projects.properties
+++ b/src/test/resources/regression/test-projects_0/test-projects.properties
@@ -1,0 +1,12 @@
+#relative path to the project root from dspot project
+project=src/test/resources/regression/test-projects_0/
+#relative path to the source project from the project properties
+src=src/main/java/
+#relative path to the test source project from the project properties
+testSrc=src/test/java
+#java version used
+javaVersion=8
+#filter used to amplify specific test cases
+filter=example.*
+#path to the output folder
+outputDirectory=dspot-out/

--- a/src/test/resources/regression/test-projects_0/test-projects.properties
+++ b/src/test/resources/regression/test-projects_0/test-projects.properties
@@ -9,4 +9,4 @@ javaVersion=8
 #filter used to amplify specific test cases
 filter=example.*
 #path to the output folder
-outputDirectory=dspot-out/
+outputDirectory=target/trash/

--- a/src/test/resources/regression/test-projects_1/cp
+++ b/src/test/resources/regression/test-projects_1/cp
@@ -1,0 +1,1 @@
+/home/bdanglot/.m2/repository/junit/junit/4.11/junit-4.11.jar:/home/bdanglot/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar

--- a/src/test/resources/regression/test-projects_1/cp
+++ b/src/test/resources/regression/test-projects_1/cp
@@ -1,1 +1,0 @@
-/home/bdanglot/.m2/repository/junit/junit/4.11/junit-4.11.jar:/home/bdanglot/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar

--- a/src/test/resources/regression/test-projects_1/pom.xml
+++ b/src/test/resources/regression/test-projects_1/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>example</groupId>
+  <artifactId>example</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>test-projects_1</name>
+
+  <properties>
+    <default.encoding>UTF-8</default.encoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+  	<dependency>
+  		<groupId>junit</groupId>
+  		<artifactId>junit</artifactId>
+  		<version>4.11</version>
+  	</dependency>
+  </dependencies>
+</project>

--- a/src/test/resources/regression/test-projects_1/src/main/java/example/Example.java
+++ b/src/test/resources/regression/test-projects_1/src/main/java/example/Example.java
@@ -1,0 +1,29 @@
+package example;
+
+public class Example {
+
+	/*
+	 * Return the index char of s 
+	 * or the last if index > s.length
+	 * or the first if index < 0			
+	 */
+	public char charAt(String s, int index){
+		
+		if ( index == 0 )
+			return s.charAt(0);
+		
+		if ( index < s.length() )
+			return s.charAt(index);
+		
+		return s.charAt(s.length()-1);
+	}
+	
+	public Example() {
+		int variableInsideConstructor;
+		variableInsideConstructor = 15; 
+		index = 2 * variableInsideConstructor;
+	}
+	
+	private int index = 419382;
+	private static String s = "Overloading field name with parameter name";
+}

--- a/src/test/resources/regression/test-projects_1/src/test/java/example/TestSuiteExample.java
+++ b/src/test/resources/regression/test-projects_1/src/test/java/example/TestSuiteExample.java
@@ -1,0 +1,46 @@
+
+
+package example;
+
+
+public class TestSuiteExample {
+
+    @org.junit.Test
+    public void test2() {
+        example.Example ex = new example.Example();
+        org.junit.Assert.assertEquals('d', ex.charAt("abcd", 3));
+    }
+
+    @org.junit.Test
+    public void test3() {
+        example.Example ex = new example.Example();
+        java.lang.String s = "abcd";
+        org.junit.Assert.assertEquals('d', ex.charAt(s, ((s.length()) - 1)));
+    }
+
+    @org.junit.Test
+    public void test4() {
+        example.Example ex = new example.Example();
+        java.lang.String s = "abcd";
+        org.junit.Assert.assertEquals('d', ex.charAt(s, 12));
+    }
+
+    @org.junit.Test
+    public void test7() {
+        example.Example ex = new example.Example();
+        org.junit.Assert.assertEquals('c', ex.charAt("abcd", 2));
+    }
+
+    @org.junit.Test
+    public void test8() {
+        example.Example ex = new example.Example();
+        org.junit.Assert.assertEquals('b', ex.charAt("abcd", 1));
+    }
+
+    @org.junit.Test
+    public void test9() {
+        example.Example ex = new example.Example();
+        org.junit.Assert.assertEquals('f', ex.charAt("abcdefghijklm", 5));
+    }
+}
+

--- a/src/test/resources/sample/src/test/java/fr/inria/sample/TestClassWithoutAssert.java
+++ b/src/test/resources/sample/src/test/java/fr/inria/sample/TestClassWithoutAssert.java
@@ -1,8 +1,5 @@
 package fr.inria.sample;
 
-import java.io.File;
-import java.util.Comparator;
-
 import org.junit.Test;
 
 /**
@@ -17,6 +14,7 @@ public class TestClassWithoutAssert {
         ClassWithBoolean cl = new ClassWithBoolean();
         cl.getFalse();
         cl.getBoolean();
+        java.io.File file = new java.io.File("");
         boolean var = cl.getTrue();
     }
 


### PR DESCRIPTION
This new Selector will reports all amplification that fail on a suspicious version of the program.

The example scenario is:

We have a stable version v0,
We have a new version v1; with potentially a regression;
We amplify test of v0, and run the obtained test on v1. If test fails, there is a potential failure, or the test encode changes.

(we could use AssertFixer on it to sligh change the oracle to fit to the new version, after it was confirmed as stable).

However, for now, this selector requiert a refactor of the loop amplification to report its results. (WIP)