### PR TITLE
Gradle Projects support: jvm options and timeout option to dspot project properties

### DIFF
--- a/src/main/java/fr/inria/diversify/automaticbuilder/GradleAutomaticBuilder.java
+++ b/src/main/java/fr/inria/diversify/automaticbuilder/GradleAutomaticBuilder.java
@@ -273,17 +273,21 @@ public class GradleAutomaticBuilder implements AutomaticBuilder {
                 "    " + OPT_WITH_HISTORY + "true" + NEW_LINE +
                 "    " + OPT_VALUE_REPORT_DIR + NEW_LINE +
                 "    " + OPT_VALUE_FORMAT + NEW_LINE +
-//                "    " + OPT_VALUE_TIMEOUT + NEW_LINE +
-//                "    " + OPT_VALUE_MEMORY + NEW_LINE +
+                (configuration.getProperty(PROPERTY_VALUE_TIMEOUT) != null ?
+                        "    " + PROPERTY_VALUE_TIMEOUT + " = " + configuration.getProperty(PROPERTY_VALUE_TIMEOUT) : "") + NEW_LINE +
+                (configuration.getProperty(PROPERTY_VALUE_JVM_ARGS) != null ?
+                        "    " + PROPERTY_VALUE_JVM_ARGS + " = " + configuration.getProperty(PROPERTY_VALUE_JVM_ARGS) : "") + NEW_LINE +
                 (testClass != null ? "    " + OPT_TARGET_TESTS + "['" + ctTypeToFullQualifiedName(testClass) + "']": "") + NEW_LINE +
                 (configuration.getProperty(PROPERTY_ADDITIONAL_CP_ELEMENTS) != null ?
-                                    "    " + OPT_ADDITIONAL_CP_ELEMENTS + "['" + configuration.getProperty(PROPERTY_ADDITIONAL_CP_ELEMENTS) + "']":"") + NEW_LINE +
+                        "    " + OPT_ADDITIONAL_CP_ELEMENTS + "['" + configuration.getProperty(PROPERTY_ADDITIONAL_CP_ELEMENTS) + "']":"") + NEW_LINE +
                 (descartesMode ? "    " + OPT_MUTATION_ENGINE :
-                                    "    " + OPT_MUTATORS + (evosuiteMode ?
-                                                    VALUE_MUTATORS_EVOSUITE : VALUE_MUTATORS_ALL)) + NEW_LINE +
+                        "    " + OPT_MUTATORS + (evosuiteMode ?
+                                VALUE_MUTATORS_EVOSUITE : VALUE_MUTATORS_ALL)) + NEW_LINE +
                 (configuration.getProperty(PROPERTY_EXCLUDED_CLASSES) != null ?
                         "    " + OPT_EXCLUDED_CLASSES +  "['" + configuration.getProperty(PROPERTY_EXCLUDED_CLASSES) + "']":"") + NEW_LINE +
                 "}" + NEW_LINE;
     }
+
+
 
 }

--- a/src/main/java/fr/inria/diversify/mutant/pit/GradlePitTaskAndOptions.java
+++ b/src/main/java/fr/inria/diversify/mutant/pit/GradlePitTaskAndOptions.java
@@ -35,9 +35,9 @@ public class GradlePitTaskAndOptions {
 
     public static final String CMD_PIT_MUTATION_COVERAGE = "pitest";
 
-    public static final String OPT_VALUE_TIMEOUT =  "timeoutConstInMillis = 10000";
+    public static final String PROPERTY_VALUE_TIMEOUT =  "timeoutConstInMillis";
 
-    public static final String OPT_VALUE_MEMORY = "jvmArgs = ['-Xms16G']";
+    public static final String PROPERTY_VALUE_JVM_ARGS = "jvmArgs";
 
     public static final String OPT_MUTATORS = "mutators = ";
 

--- a/src/test/resources/test-projects/test-projects.properties
+++ b/src/test/resources/test-projects/test-projects.properties
@@ -10,3 +10,11 @@ javaVersion=8
 filter=example.*
 #path to the output folder
 outputDirectory=target/trash/
+# Constant amount of additional time to allow a test to run for
+# before considering it to be stuck in an infinite loop
+timeoutConstInMillis=10000
+#Argument string to use when PIT launches child processes. This is most commonly used
+# to increase the amount of memory available to the process,
+# but may be used to pass any valid JVM argument.
+# Use commas to separate multiple arguments, and put them within brackets
+jvmArgs=['-Xmx2048m','-Xms1024m']


### PR DESCRIPTION
Hi @danglotb , I moved jvm options and timeout option management to the target project properties. Now if you want to use these two options within Gradle Projects, you have to add them to that file. You can see an example below in the test-projects.properties file (I put some comments to explain). I run all tests locally and in Travis, and everything went fine. In a couple of days I will add also the support to descartes mutators.
