### PR TITLE
WIP : Pit as Library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,18 +42,36 @@
             <groupId>fr.inria.diversify.sosiefier</groupId>
             <artifactId>core</artifactId>
             <version>1.0.0</version>
+            <exclusions>
+                <exclusion>  <!-- declare the exclusion here -->
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-debug-all</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>fr.inria.diversify.sosiefier</groupId>
             <artifactId>generator</artifactId>
             <version>1.0.0</version>
+            <exclusions>
+                <exclusion>  <!-- declare the exclusion here -->
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-debug-all</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>fr.inria.diversify.sosiefier</groupId>
             <artifactId>diversify-profiling</artifactId>
             <version>1.0.0</version>
+            <exclusions>
+                <exclusion>  <!-- declare the exclusion here -->
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-debug-all</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -68,11 +86,11 @@
             <version>2.8.0</version>
         </dependency>
 
-        <dependency>
+        <!--<dependency>
             <groupId>fr.inria.stamp</groupId>
             <artifactId>descartes</artifactId>
             <version>0.1-SNAPSHOT</version>
-        </dependency>
+        </dependency>-->
 
         <dependency>
             <groupId>org.gradle</groupId>
@@ -84,6 +102,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>2.8.47</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-entry</artifactId>
+            <version>1.2.3</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/fr/inria/stamp/test/runner/DefaultTestRunner.java
+++ b/src/main/java/fr/inria/stamp/test/runner/DefaultTestRunner.java
@@ -1,6 +1,5 @@
 package fr.inria.stamp.test.runner;
 
-import edu.emory.mathcs.backport.java.util.Collections;
 import fr.inria.diversify.logger.Logger;
 import fr.inria.stamp.test.filter.MethodFilter;
 import fr.inria.stamp.test.listener.TestListener;
@@ -11,6 +10,7 @@ import org.junit.runner.notification.RunNotifier;
 
 import java.net.URLClassLoader;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.*;
 
 /**

--- a/src/test/java/fr/inria/diversify/dspot/DSpotMockedTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/DSpotMockedTest.java
@@ -1,6 +1,5 @@
 package fr.inria.diversify.dspot;
 
-import edu.emory.mathcs.backport.java.util.Collections;
 import fr.inria.diversify.buildSystem.android.InvalidSdkException;
 import fr.inria.diversify.dspot.amplifier.value.ValueCreator;
 import fr.inria.diversify.runner.InputConfiguration;
@@ -8,13 +7,12 @@ import fr.inria.diversify.runner.InputProgram;
 import fr.inria.diversify.util.FileUtils;
 import fr.inria.diversify.utils.AmplificationHelper;
 import org.junit.Test;
-import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 
 import java.io.File;
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Created by Benjamin DANGLOT

--- a/src/test/java/fr/inria/diversify/dspot/DSpotTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/DSpotTest.java
@@ -2,7 +2,6 @@ package fr.inria.diversify.dspot;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import edu.emory.mathcs.backport.java.util.Collections;
 import fr.inria.diversify.buildSystem.android.InvalidSdkException;
 import fr.inria.diversify.dspot.support.json.ProjectTimeJSON;
 import fr.inria.diversify.dspot.amplifier.value.ValueCreator;
@@ -10,7 +9,6 @@ import fr.inria.diversify.runner.InputConfiguration;
 import fr.inria.diversify.runner.InputProgram;
 import fr.inria.diversify.util.FileUtils;
 import fr.inria.diversify.utils.AmplificationHelper;
-import fr.inria.diversify.utils.DSpotUtils;
 import org.junit.Test;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;

--- a/src/test/java/fr/inria/diversify/dspot/ProjectJSONTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/ProjectJSONTest.java
@@ -1,6 +1,5 @@
 package fr.inria.diversify.dspot;
 
-import edu.emory.mathcs.backport.java.util.Collections;
 import fr.inria.diversify.Utils;
 import fr.inria.diversify.buildSystem.android.InvalidSdkException;
 import fr.inria.diversify.dspot.amplifier.TestDataMutator;
@@ -12,6 +11,7 @@ import org.junit.Test;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 import static fr.inria.diversify.dspot.AbstractTest.nl;

--- a/src/test/java/fr/inria/diversify/dspot/amplifier/value/TestValueCreator.java
+++ b/src/test/java/fr/inria/diversify/dspot/amplifier/value/TestValueCreator.java
@@ -1,19 +1,17 @@
 package fr.inria.diversify.dspot.amplifier.value;
 
-import edu.emory.mathcs.backport.java.util.Collections;
 import fr.inria.diversify.Utils;
 import fr.inria.diversify.buildSystem.android.InvalidSdkException;
 import fr.inria.diversify.dspot.AbstractTest;
-import fr.inria.diversify.dspot.amplifier.value.ValueCreator;
 import fr.inria.diversify.utils.AmplificationHelper;
 import org.junit.Test;
-import spoon.Launcher;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 

--- a/src/test/java/fr/inria/diversify/dspot/selector/ChangeDetectorSelectorTest.java
+++ b/src/test/java/fr/inria/diversify/dspot/selector/ChangeDetectorSelectorTest.java
@@ -1,17 +1,16 @@
 package fr.inria.diversify.dspot.selector;
 
-import edu.emory.mathcs.backport.java.util.Collections;
 import fr.inria.diversify.buildSystem.android.InvalidSdkException;
 import fr.inria.diversify.dspot.DSpot;
 import fr.inria.diversify.dspot.amplifier.StatementAdd;
 import fr.inria.diversify.runner.InputConfiguration;
 import org.junit.Test;
-import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
+
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Created by Benjamin DANGLOT

--- a/src/test/java/fr/inria/diversify/mutant/descartes/PitDescartesTest.java
+++ b/src/test/java/fr/inria/diversify/mutant/descartes/PitDescartesTest.java
@@ -1,31 +1,21 @@
 package fr.inria.diversify.mutant.descartes;
 
-import edu.emory.mathcs.backport.java.util.Collections;
-import fr.inria.diversify.Utils;
 import fr.inria.diversify.automaticbuilder.AutomaticBuilderFactory;
-import fr.inria.diversify.automaticbuilder.MavenAutomaticBuilder;
 import fr.inria.diversify.buildSystem.android.InvalidSdkException;
 import fr.inria.diversify.dspot.amplifier.StatementAdd;
 import fr.inria.diversify.utils.AmplificationHelper;
 import fr.inria.diversify.dspot.DSpot;
-import fr.inria.diversify.dspot.amplifier.StatementAdderOnAssert;
-import fr.inria.diversify.dspot.amplifier.TestDataMutator;
-import fr.inria.diversify.dspot.amplifier.TestMethodCallAdder;
 import fr.inria.diversify.dspot.selector.PitMutantScoreSelector;
 import fr.inria.diversify.mutant.pit.MavenPitCommandAndOptions;
 import fr.inria.diversify.runner.InputConfiguration;
-import fr.inria.diversify.runner.InputProgram;
 import fr.inria.diversify.util.FileUtils;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import spoon.reflect.declaration.CtClass;
-import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 
 import java.io.*;
-import java.util.Arrays;
-import java.util.function.Predicate;
+import java.util.Collections;
 
 import static org.junit.Assert.*;
 

--- a/src/test/java/fr/inria/diversify/utils/TypeUtilsTest.java
+++ b/src/test/java/fr/inria/diversify/utils/TypeUtilsTest.java
@@ -1,10 +1,9 @@
 package fr.inria.diversify.utils;
 
-import edu.emory.mathcs.backport.java.util.Collections;
 import org.junit.Test;
 
-import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/fr/inria/stamp/Playground.java
+++ b/src/test/java/fr/inria/stamp/Playground.java
@@ -1,0 +1,100 @@
+package fr.inria.stamp;
+
+import org.junit.Test;
+import org.pitest.mutationtest.config.PluginServices;
+import org.pitest.mutationtest.config.ReportOptions;
+import org.pitest.mutationtest.config.SettingsFactory;
+import org.pitest.mutationtest.tooling.EntryPoint;
+import org.pitest.testapi.TestGroupConfig;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Created by Benjamin DANGLOT
+ * benjamin.danglot@inria.fr
+ * on 20/09/17
+ */
+public class Playground {
+
+	public class Tacos {
+
+	}
+
+	public class Benjamin {
+		public void eat(Tacos tacos) {
+
+		}
+		public boolean isHungry() {
+			return true;
+		}
+	}
+
+	@Test
+	public void testTacos() throws Exception {
+		Tacos tacos = new Tacos();
+		Benjamin benjamin = new Benjamin();
+		benjamin.eat(tacos);
+		assertFalse(benjamin.isHungry());
+	}
+
+	@Test
+	public void testLaunchPit() throws Exception {
+		final ReportOptions data = createReportOptions();
+		final SettingsFactory settingsFactory = createSettingFactory(data);
+		final EntryPoint e = new EntryPoint();
+		e.execute(new File("src/test/resources/test-projects/"), data, settingsFactory, Collections.emptyMap());
+	}
+
+	private ReportOptions createReportOptions() {
+		final ReportOptions data = new ReportOptions();
+		final List<String> classpathList = Arrays.stream(((URLClassLoader) ClassLoader.getSystemClassLoader()).getURLs())
+				.map(URL::getFile)
+				.collect(Collectors.toList());
+		classpathList.add("src/test/resources/test-projects/target/classes");
+		classpathList.add("src/test/resources/test-projects/target/test-classes/");
+		data.setClassPathElements(classpathList);
+		data.setDependencyAnalysisMaxDistance(-1);
+		data.setTargetClasses(Collections.singletonList(string -> string.startsWith("example.")));
+		data.setTargetTests(Collections.singletonList("example.TestSuiteExample"::equals));
+		data.setReportDir("target/report-pits/");
+		data.setVerbose(true);
+		data.setMutators(Collections.singletonList("ALL"));
+		data.setSourceDirs(Collections.singletonList(new File("src/test/resources/test-projects/")));
+		data.addOutputFormats(Collections.singletonList("CSV"));
+		final TestGroupConfig testGroupConfig = new TestGroupConfig(Collections.emptyList(), Collections.emptyList());
+		data.setGroupConfig(testGroupConfig);
+		data.setExportLineCoverage(true);
+		data.setMutationEngine("gregor");
+		return data;
+	}
+
+	private SettingsFactory createSettingFactory(ReportOptions data) {
+
+		final String classpath = "/home/bdanglot/.m2/repository/junit/junit/4.11/junit-4.11.jar:" +
+				"/home/bdanglot/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar:" +
+				"src/test/resources/test-projects/target/classes:" +
+				"src/test/resources/test-projects/target/test-classes/";
+
+		final URL[] urls = Arrays.stream(classpath.split(":"))
+				.map(File::new)
+				.map(file -> {
+					try {
+						return file.toURI().toURL();
+					} catch (Exception e) {
+						throw new RuntimeException(e);
+					}
+				}).toArray(URL[]::new);
+		ClassLoader classLoader = new URLClassLoader(urls);
+
+		return new SettingsFactory(data, new PluginServices(classLoader));
+	}
+}
+


### PR DESCRIPTION
This pull request at using pit as library and remove the usage of the maven invoker.

The problem for now, I am not be able to compute the code coverage with pit before running the mutation.

see my post on the [Google Code Group](https://groups.google.com/forum/#!topic/pitusers/5ACAauE5Gdk).

Excerpt Output:

It runs all tests:
```
9:43:21 AM PIT >> INFO : MINION : 9:43:21 AM PIT >> FINE : Gathering coverage for test Description [testClass=example.TestSuiteExample, name=test2(example.TestSuiteExample)]
```
But no mutation has been executed:
```
9:43:22 AM PIT >> FINE : According to coverage no tests hit the mutation MutationDetails [id=MutationIdentifier [location=Location [clazz=example.Example, method=charAt, methodDesc=(Ljava/lang/String;I)C], indexes=[4], mutator=org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_ORDER_IF], filename=Example.java, block=0, lineNumber=12, description=removed conditional - replaced comparison check with true, testsInOrder=[], isInFinallyBlock=false, poison=NORMAL]
```