### PR TITLE
docs: fix the documentation according to the usage of PIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Here is the list of configuration properties of DSpot:
   * maven.home: path to the executable maven. If no value is specified, it will try some defaults values
     (for instance: `/usr/share/maven/`, `usr/local/Cellar/maven/3.3.9/libexec/` ...).
 * optional properties:
-  * filter: filter on the package name containing tests to be executed (_e.g._ `example.*`) passed to Pitest. The default value is built automatically by PIT based on your pom.xml: `groupid.artifactid.*`. We suggest you to give the topest package of your project. (_e.g._ for the test-projects it would be `example.*`)
+  * filter: filter on the package name containing tests to be executed (_e.g._ `example.*`) passed to Pitest. If not set, the default value is set automatically by PIT based on the pom.xml data as follows: `filter=<groupid>.<artifactid>.*`. If you set it, we recommand to give the top-most package of your project. (_e.g._ for the test-projects it would be `example.*`)
   * maven.localRepository: path to the local repository of Maven (.m2), if you need specific settings.
   * excludedClasses: DSpot will not amplify the excluded test classes.
   * additionalClasspathElements: add elements to the classpath. (e.g. a jar file)

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Here is the list of configuration properties of DSpot:
   * maven.home: path to the executable maven. If no value is specified, it will try some defaults values
     (for instance: `/usr/share/maven/`, `usr/local/Cellar/maven/3.3.9/libexec/` ...).
 * optional properties:
-  * filter: filter on the package name containing tests to be executed (eg "example.*") passed to Pitest. Default is "*" (all test classes). If "*", ensures that the newly killed mutants are not killed by any other tests.
+  * filter: filter on the package name containing tests to be executed (_e.g._ `example.*`) passed to Pitest. The default value is built automatically by PIT based on your pom.xml: `groupid.artifactid.*`. We suggest you to give the topest package of your project. (_e.g._ for the test-projects it would be `example.*`)
   * maven.localRepository: path to the local repository of Maven (.m2), if you need specific settings.
   * excludedClasses: DSpot will not amplify the excluded test classes.
   * additionalClasspathElements: add elements to the classpath. (e.g. a jar file)

--- a/dspot/src/test/java/fr/inria/diversify/automaticbuilder/MavenAutomaticBuilderTest.java
+++ b/dspot/src/test/java/fr/inria/diversify/automaticbuilder/MavenAutomaticBuilderTest.java
@@ -3,6 +3,7 @@ package fr.inria.diversify.automaticbuilder;
 import fr.inria.Utils;
 import fr.inria.diversify.mutant.pit.PitResult;
 import fr.inria.diversify.mutant.pit.PitResultParser;
+import fr.inria.diversify.utils.sosiefier.InputConfiguration;
 import fr.inria.stamp.Main;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -41,7 +42,7 @@ public class MavenAutomaticBuilderTest {
 
         try {
             FileUtils.forceDelete(new File("src/test/resources/test-projects//target/dspot/classpath"));
-        } catch (Exception ignored){
+        } catch (Exception ignored) {
             //ignored
         }
 
@@ -144,5 +145,21 @@ public class MavenAutomaticBuilderTest {
         assertNotNull(pitResults);
         assertEquals(88, pitResults.size());
 
+    }
+
+    @Test
+    public void testUsingStarFilter() throws Exception {
+        Main.verbose = true;
+        Utils.init("src/test/resources/test-projects/test-projects.properties");
+
+        final InputConfiguration inputConfiguration = Utils.getInputConfiguration();
+        inputConfiguration.getProperties().setProperty("filter", "*");
+        try {
+            Utils.getBuilder().runPit(Utils.getInputProgram().getProgramDir(), Utils.findClass("example.TestSuiteExample2"), Utils.findClass("example.TestSuiteExample"));
+            fail();
+        } catch (Exception e) {
+
+        }
+        Main.verbose = false;
     }
 }


### PR DESCRIPTION
We cannot give `*` as filter since when we do that PIT would mutate itself.

When the maven goals are called using `filter=*`, PIT throws the following errors:

```
[ERROR] Failed to execute goal org.pitest:pitest-maven:1.3.0:mutationCoverage (default-cli) on project example:
    Execution default-cli of goal org.pitest:pitest-maven:1.3.0:mutationCoverage failed:
    The supplied filter would cause PIT to try and mutate itself. 
    This will lead to many wasted hours of confusion and debugging. 
    You have better things to do with your life so please don't do this again.
```

Therefore, I updated the documentation according to this: users must provide a correct `filter` or have a correct packages/pom according to maven conventions.