### PR TITLE
WIP refactor: move the factory from InputProgram to InputConfiguration

### DIFF
--- a/dspot/src/main/java/eu/stamp_project/automaticbuilder/MavenAutomaticBuilder.java
+++ b/dspot/src/main/java/eu/stamp_project/automaticbuilder/MavenAutomaticBuilder.java
@@ -48,7 +48,7 @@ public class MavenAutomaticBuilder implements AutomaticBuilder {
 	MavenAutomaticBuilder(InputConfiguration configuration) {
 		this.mavenHome = DSpotUtils.buildMavenHome(configuration);
 		this.configuration = configuration;
-		final String pathToPom = this.configuration.getInputProgram().getProgramDir() + "/" + POM_FILE;
+		final String pathToPom = this.configuration.getAbsolutePathToProjectRoot() + "/" + POM_FILE;
 		if (PitMutantScoreSelector.descartesMode &&
 				DescartesChecker.shouldInjectDescartes(pathToPom)) {
 			try (final BufferedReader buffer = new BufferedReader(new FileReader(pathToPom))) {
@@ -99,7 +99,7 @@ public class MavenAutomaticBuilder implements AutomaticBuilder {
 	@Override
 	public void reset() {
 		if (contentOfOriginalPom != null) {
-			final String pathToPom = this.configuration.getInputProgram().getProgramDir() + "/" + POM_FILE;
+			final String pathToPom = this.configuration.getAbsolutePathToProjectRoot() + "/" + POM_FILE;
 			try (FileWriter writer = new FileWriter(pathToPom)) {
 				writer.write(this.contentOfOriginalPom);
 				this.contentOfOriginalPom =  null;

--- a/dspot/src/main/java/eu/stamp_project/clover/CloverExecutor.java
+++ b/dspot/src/main/java/eu/stamp_project/clover/CloverExecutor.java
@@ -63,7 +63,7 @@ public class CloverExecutor {
         });
 
         final String classpath = AutomaticBuilderFactory.getAutomaticBuilder(configuration)
-                .buildClasspath(configuration.getInputProgram().getProgramDir());
+                .buildClasspath(configuration.getAbsolutePathToProjectRoot());
         final String finalClasspath = classpath +
                 AmplificationHelper.PATH_SEPARATOR + rootDirectoryOfCloverFiles.getAbsolutePath() + INSTR_BIN_DIRECTORY +
                 AmplificationHelper.PATH_SEPARATOR + CLOVER_DEPENDENCIES;

--- a/dspot/src/main/java/eu/stamp_project/diff/SelectorOnDiff.java
+++ b/dspot/src/main/java/eu/stamp_project/diff/SelectorOnDiff.java
@@ -50,7 +50,7 @@ public class SelectorOnDiff {
      * @return a map that associates the full qualified name of test classes to their test methods to be amplified.
      */
     public static Map<String, List<String>> findTestMethodsAccordingToADiff(InputConfiguration configuration) {
-        final Factory factory = configuration.getInputProgram().getFactory();
+        final Factory factory = configuration.getFactory();
         final String baseSha = configuration.getProperties().getProperty("baseSha");
         final String pathToFirstVersion = configuration.getProperties().getProperty("project") +
                 (configuration.getProperties().getProperty("targetModule") != null ?

--- a/dspot/src/main/java/eu/stamp_project/dspot/DSpot.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/DSpot.java
@@ -106,7 +106,7 @@ public class DSpot {
         }
 
         this.compiler = DSpotCompiler.createDSpotCompiler(inputProgram, dependencies);
-        this.inputProgram.setFactory(compiler.getLauncher().getFactory());
+        this.inputConfiguration.setFactory(compiler.getLauncher().getFactory());
         this.amplifiers = new ArrayList<>(amplifiers);
         this.numberOfIterations = numberOfIterations;
         this.testSelector = testSelector;
@@ -131,7 +131,7 @@ public class DSpot {
     }
 
     public List<CtType> amplifyAllTests() {
-        return this.amplifyAllTests(inputProgram.getFactory().Class().getAll().stream()
+        return this.amplifyAllTests(this.inputConfiguration.getFactory().Class().getAll().stream()
                 .filter(ctClass -> !ctClass.getModifiers().contains(ModifierKind.ABSTRACT))
                 .filter(ctClass ->
                         ctClass.getMethods().stream()
@@ -228,8 +228,13 @@ public class DSpot {
         }
     }
 
+    @Deprecated
     public InputProgram getInputProgram() {
         return inputProgram;
+    }
+
+    public InputConfiguration getInputConfiguration() {
+        return this.inputConfiguration;
     }
 
     private final Predicate<CtType> isExcluded = ctType ->

--- a/dspot/src/main/java/eu/stamp_project/dspot/DSpot.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/DSpot.java
@@ -98,21 +98,21 @@ public class DSpot {
         this.inputProgram = inputConfiguration.getInputProgram();
 
         AutomaticBuilder builder = AutomaticBuilderFactory.getAutomaticBuilder(inputConfiguration);
-        String dependencies = builder.buildClasspath(this.inputProgram.getProgramDir());
+        String dependencies = builder.buildClasspath(this.inputConfiguration.getAbsolutePathToProjectRoot());
 
         if (inputConfiguration.getProperty("additionalClasspathElements") != null) {
-            dependencies += PATH_SEPARATOR + new File(inputConfiguration.getInputProgram().getProgramDir()
+            dependencies += PATH_SEPARATOR + new File(this.inputConfiguration.getAbsolutePathToProjectRoot()
                     + inputConfiguration.getProperty("additionalClasspathElements")).getAbsolutePath();
         }
 
-        this.compiler = DSpotCompiler.createDSpotCompiler(inputProgram, dependencies);
+        this.compiler = DSpotCompiler.createDSpotCompiler(this.inputConfiguration, dependencies);
         this.inputConfiguration.setFactory(compiler.getLauncher().getFactory());
         this.amplifiers = new ArrayList<>(amplifiers);
         this.numberOfIterations = numberOfIterations;
         this.testSelector = testSelector;
         this.testSelector.init(this.inputConfiguration);
 
-        final String[] splittedPath = inputProgram.getProgramDir().split("/");
+        final String[] splittedPath = this.inputConfiguration.getAbsolutePathToProjectRoot().split("/");
         final File projectJsonFile = new File(this.inputConfiguration.getOutputDirectory() +
                 "/" + splittedPath[splittedPath.length - 1] + ".json");
         if (projectJsonFile.exists()) {

--- a/dspot/src/main/java/eu/stamp_project/dspot/assertGenerator/MethodsAssertGenerator.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/assertGenerator/MethodsAssertGenerator.java
@@ -50,7 +50,7 @@ public class MethodsAssertGenerator {
         this.originalClass = originalClass;
         this.configuration = configuration;
         this.compiler = compiler;
-        this.factory = configuration.getInputProgram().getFactory();
+        this.factory = configuration.getFactory();
     }
 
     /**

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/ChangeDetectorSelector.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/ChangeDetectorSelector.java
@@ -65,7 +65,7 @@ public class ChangeDetectorSelector implements TestSelector {
                         DSpotUtils.shouldAddSeparator.apply(pathToFolder);
                 configuration.getProperties().setProperty("targetModule", this.configuration.getProperty("targetModule"));
             }
-            this.configuration.setAbsolutePathToProjectRoot(new File(this.pathToChangedVersionOfProgram).getAbsolutePath());
+            inputConfiguration.setAbsolutePathToProjectRoot(new File(this.pathToChangedVersionOfProgram).getAbsolutePath());
             inputProgram.setProgramDir(this.pathToChangedVersionOfProgram);
             Initializer.initialize(inputConfiguration, inputProgram);
         } catch (Exception e) {
@@ -98,15 +98,15 @@ public class ChangeDetectorSelector implements TestSelector {
         DSpotUtils.printCtTypeToGivenDirectory(clone, new File(DSpotCompiler.pathToTmpTestSources));
         final String classpath = AutomaticBuilderFactory
                 .getAutomaticBuilder(this.configuration)
-                .buildClasspath(this.program.getProgramDir())
+                .buildClasspath(this.configuration.getAbsolutePathToProjectRoot())
                 + AmplificationHelper.PATH_SEPARATOR + "target/dspot/dependencies/";
 
         DSpotCompiler.compile(DSpotCompiler.pathToTmpTestSources,
                 classpath
                         + AmplificationHelper.PATH_SEPARATOR +
-                        this.program.getProgramDir() + "/" + this.program.getClassesDir()
+                        this.configuration.getAbsolutePathToProjectRoot() + "/" + this.program.getClassesDir()
                         + AmplificationHelper.PATH_SEPARATOR +
-                        this.program.getProgramDir() + "/" + this.program.getTestClassesDir(),
+                        this.configuration.getAbsolutePathToProjectRoot() + "/" + this.program.getTestClassesDir(),
                 new File(this.pathToChangedVersionOfProgram + "/" + this.program.getTestClassesDir()));
 
         final TestListener results;

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/ChangeDetectorSelector.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/ChangeDetectorSelector.java
@@ -65,6 +65,7 @@ public class ChangeDetectorSelector implements TestSelector {
                         DSpotUtils.shouldAddSeparator.apply(pathToFolder);
                 configuration.getProperties().setProperty("targetModule", this.configuration.getProperty("targetModule"));
             }
+            this.configuration.setAbsolutePathToProjectRoot(new File(this.pathToChangedVersionOfProgram).getAbsolutePath());
             inputProgram.setProgramDir(this.pathToChangedVersionOfProgram);
             Initializer.initialize(inputConfiguration, inputProgram);
         } catch (Exception e) {

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/CloverCoverageSelector.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/CloverCoverageSelector.java
@@ -55,7 +55,7 @@ public class CloverCoverageSelector extends TakeAllSelector {
                     .map(lineCoveragePerTestMethods::get)
                     .forEach(lineCoveragePerTestMethod ->
                             lineCoveragePerTestMethod.keySet().forEach(className -> {
-                                        final CtType<?> key = program.getFactory().Type().get(className);
+                                        final CtType<?> key = configuration.getFactory().Type().get(className);
                                         if (!this.originalLineCoveragePerClass.containsKey(key)) {
                                             this.originalLineCoveragePerClass.put(key, new HashSet<>());
                                         }
@@ -125,7 +125,7 @@ public class CloverCoverageSelector extends TakeAllSelector {
                                                 .stream()
                                                 .anyMatch(executedLine ->
                                                         !this.originalLineCoveragePerClass.get(
-                                                                this.configuration.getInputProgram().getFactory().Type().get(className)
+                                                                this.configuration.getFactory().Type().get(className)
                                                         ).contains(executedLine)
                                                 )
                                 )

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/CloverCoverageSelector.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/CloverCoverageSelector.java
@@ -64,12 +64,12 @@ public class CloverCoverageSelector extends TakeAllSelector {
                             )
                     );
 
-            final String classesOfProject = new File(program.getProgramDir() + program.getClassesDir()).getAbsolutePath() +
-                    AmplificationHelper.PATH_SEPARATOR +
-                    new File(program.getProgramDir() + program.getTestClassesDir()).getAbsolutePath();
+            final String classesOfProject = new File(configuration.getAbsolutePathToProjectRoot() + program.getClassesDir()).getAbsolutePath()
+                    + AmplificationHelper.PATH_SEPARATOR +
+                    new File(configuration.getAbsolutePathToProjectRoot() + program.getTestClassesDir()).getAbsolutePath();
 
             final String classpath = AutomaticBuilderFactory.getAutomaticBuilder(this.configuration)
-                    .buildClasspath(program.getProgramDir()) +
+                    .buildClasspath(configuration.getAbsolutePathToProjectRoot()) +
                     AmplificationHelper.PATH_SEPARATOR + classesOfProject;
 
             try {
@@ -176,16 +176,16 @@ public class CloverCoverageSelector extends TakeAllSelector {
         DSpotUtils.printCtTypeToGivenDirectory(clone, new File(DSpotCompiler.pathToTmpTestSources));
 
         final String classesOfProject =
-                new File(program.getProgramDir() + program.getClassesDir()).getAbsolutePath() +
-                AmplificationHelper.PATH_SEPARATOR +
-                        new File(program.getProgramDir() + program.getTestClassesDir()).getAbsolutePath();
+                new File(configuration.getAbsolutePathToProjectRoot() + program.getClassesDir()).getAbsolutePath()
+                        + AmplificationHelper.PATH_SEPARATOR +
+                        new File(configuration.getAbsolutePathToProjectRoot() + program.getTestClassesDir()).getAbsolutePath();
 
         final String classpath = AutomaticBuilderFactory.getAutomaticBuilder(this.configuration)
-                .buildClasspath(program.getProgramDir()) +
+                .buildClasspath(configuration.getAbsolutePathToProjectRoot()) +
                 AmplificationHelper.PATH_SEPARATOR + classesOfProject;
 
         DSpotCompiler.compile(DSpotCompiler.pathToTmpTestSources, classpath,
-                new File(this.program.getProgramDir() + "/" + this.program.getTestClassesDir()));
+                new File(this.configuration.getAbsolutePathToProjectRoot() + "/" + this.program.getTestClassesDir()));
 
         try {
             return EntryPoint.runCoverageOnTestClasses(classpath, classesOfProject,

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/ExecutedMutantSelector.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/ExecutedMutantSelector.java
@@ -62,10 +62,10 @@ public class ExecutedMutantSelector extends TakeAllSelector {
         if (this.originalMutantExecuted == null) {
             LOGGER.info("Computing executed mutants by the original test suite...");
             final AutomaticBuilder automaticBuilder = AutomaticBuilderFactory.getAutomaticBuilder(this.configuration);
-            automaticBuilder.runPit(this.program.getProgramDir());
+            automaticBuilder.runPit(this.configuration.getAbsolutePathToProjectRoot());
             this.originalMutantExecuted =
                     PitResultParser.parseAndDelete(
-                            this.program.getProgramDir() + automaticBuilder.getOutputDirectoryPit()
+                            this.configuration.getAbsolutePathToProjectRoot() + automaticBuilder.getOutputDirectoryPit()
                     ).stream().filter(pitResult -> pitResult.getStateOfMutant() == PitResult.State.KILLED ||
                             pitResult.getStateOfMutant() == PitResult.State.SURVIVED)
                             .collect(Collectors.toList());
@@ -102,20 +102,20 @@ public class ExecutedMutantSelector extends TakeAllSelector {
         // then compile
         final String classpath = AutomaticBuilderFactory
                 .getAutomaticBuilder(this.configuration)
-                .buildClasspath(this.program.getProgramDir())
+                .buildClasspath(this.configuration.getAbsolutePathToProjectRoot())
                 + AmplificationHelper.PATH_SEPARATOR +
-                this.program.getProgramDir() + "/" + this.program.getClassesDir()
+                this.configuration.getAbsolutePathToProjectRoot() + "/" + this.program.getClassesDir()
                 + AmplificationHelper.PATH_SEPARATOR + "target/dspot/dependencies/"
                 + AmplificationHelper.PATH_SEPARATOR +
-                this.program.getProgramDir() + "/" + this.program.getTestClassesDir();
+                this.configuration.getAbsolutePathToProjectRoot() + "/" + this.program.getTestClassesDir();
 
         DSpotCompiler.compile(DSpotCompiler.pathToTmpTestSources, classpath,
-                new File(this.program.getProgramDir() + "/" + this.program.getTestClassesDir()));
+                new File(this.configuration.getAbsolutePathToProjectRoot() + "/" + this.program.getTestClassesDir()));
 
         AutomaticBuilderFactory
                 .getAutomaticBuilder(this.configuration)
-                .runPit(this.program.getProgramDir(), clone);
-        final List<PitResult> pitResults = PitResultParser.parseAndDelete(program.getProgramDir() + AutomaticBuilderFactory
+                .runPit(this.configuration.getAbsolutePathToProjectRoot(), clone);
+        final List<PitResult> pitResults = PitResultParser.parseAndDelete(this.configuration.getAbsolutePathToProjectRoot() + AutomaticBuilderFactory
                 .getAutomaticBuilder(this.configuration).getOutputDirectoryPit());
         final int numberOfSelectedAmplifiedTest = pitResults.stream()
                 .filter(pitResult -> pitResult.getStateOfMutant() == PitResult.State.KILLED ||

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/JacocoCoverageSelector.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/JacocoCoverageSelector.java
@@ -53,15 +53,15 @@ public class JacocoCoverageSelector extends TakeAllSelector {
     public List<CtMethod<?>> selectToAmplify(List<CtMethod<?>> testsToBeAmplified) {
         if (this.currentClassTestToBeAmplified == null && !testsToBeAmplified.isEmpty()) {
             this.currentClassTestToBeAmplified = testsToBeAmplified.get(0).getDeclaringType();
-            String classpath = AutomaticBuilderFactory.getAutomaticBuilder(this.configuration).buildClasspath(this.program.getProgramDir());
+            String classpath = AutomaticBuilderFactory.getAutomaticBuilder(this.configuration).buildClasspath(this.configuration.getAbsolutePathToProjectRoot());
             if (this.configuration.getProperty("additionalClasspathElements") != null) {
-                classpath += PATH_SEPARATOR + new File(this.configuration.getInputProgram().getProgramDir()
+                classpath += PATH_SEPARATOR + new File(this.configuration.getAbsolutePathToProjectRoot()
                         + this.configuration.getProperty("additionalClasspathElements")).getAbsolutePath();
             }
             final String targetClasses =
-                    new File(this.program.getProgramDir() + (this.program.getProgramDir().endsWith("/") ? "" : "/") + this.program.getClassesDir()).getAbsolutePath() +
-                            AmplificationHelper.PATH_SEPARATOR +
-                            new File(this.program.getProgramDir() + (this.program.getProgramDir().endsWith("/") ? "" : "/") + this.program.getTestClassesDir()).getAbsolutePath();
+                    new File(this.configuration.getAbsolutePathToProjectRoot() + (this.configuration.getAbsolutePathToProjectRoot().endsWith("/") ? "" : "/") + this.program.getClassesDir()).getAbsolutePath() +
+                    AmplificationHelper.PATH_SEPARATOR +
+                    new File(this.configuration.getAbsolutePathToProjectRoot() + (this.configuration.getAbsolutePathToProjectRoot().endsWith("/") ? "" : "/") + this.program.getTestClassesDir()).getAbsolutePath();
             try {
                 initialCoverage = EntryPoint.runCoverageOnTestClasses(
                         classpath + AmplificationHelper.PATH_SEPARATOR + targetClasses,
@@ -103,15 +103,16 @@ public class JacocoCoverageSelector extends TakeAllSelector {
 
     private CoveragePerTestMethod computeCoverageForGivenTestMethdods(List<CtMethod<?>> testsToBeAmplified) {
         final String[] methodNames = testsToBeAmplified.stream().map(CtNamedElement::getSimpleName).toArray(String[]::new);
-        String classpath = AutomaticBuilderFactory.getAutomaticBuilder(this.configuration).buildClasspath(this.program.getProgramDir());
+        String classpath = AutomaticBuilderFactory.getAutomaticBuilder(this.configuration).buildClasspath(this.configuration.getAbsolutePathToProjectRoot());
         if (this.configuration.getProperty("additionalClasspathElements") != null) {
-            classpath += PATH_SEPARATOR + new File(this.configuration.getInputProgram().getProgramDir()
+            classpath += PATH_SEPARATOR +
+                    new File(this.configuration.getAbsolutePathToProjectRoot()
                     + this.configuration.getProperty("additionalClasspathElements")).getAbsolutePath();
         }
         final String targetClasses =
-                new File(this.program.getProgramDir() + (this.program.getProgramDir().endsWith("/") ? "" : "/") + this.program.getClassesDir()).getAbsolutePath() +
-                        AmplificationHelper.PATH_SEPARATOR +
-                        new File(this.program.getProgramDir() + (this.program.getProgramDir().endsWith("/") ? "" : "/") + this.program.getTestClassesDir()).getAbsolutePath();
+                new File(this.configuration.getAbsolutePathToProjectRoot() + (this.configuration.getAbsolutePathToProjectRoot().endsWith("/") ? "" : "/") + this.program.getClassesDir()).getAbsolutePath() +
+                AmplificationHelper.PATH_SEPARATOR +
+                new File(this.configuration.getAbsolutePathToProjectRoot() + (this.configuration.getAbsolutePathToProjectRoot().endsWith("/") ? "" : "/") + this.program.getTestClassesDir()).getAbsolutePath();
         try {
             return EntryPoint.runCoveragePerTestMethods(
                     classpath + AmplificationHelper.PATH_SEPARATOR + targetClasses,
@@ -198,23 +199,23 @@ public class JacocoCoverageSelector extends TakeAllSelector {
         final String fileSeparator = System.getProperty("file.separator");
         String classpath = AutomaticBuilderFactory
                 .getAutomaticBuilder(this.configuration)
-                .buildClasspath(this.program.getProgramDir())
+                .buildClasspath(this.configuration.getAbsolutePathToProjectRoot())
                 + System.getProperty("path.separator") +
-                new File(this.program.getProgramDir() + fileSeparator + this.program.getClassesDir()).getAbsolutePath()
-                + System.getProperty("path.separator") +
-                new File(this.program.getProgramDir() + fileSeparator + this.program.getTestClassesDir()).getAbsolutePath();
+                new File(this.configuration.getAbsolutePathToProjectRoot() + fileSeparator + this.program.getClassesDir()).getAbsolutePath()
+                + AmplificationHelper.PATH_SEPARATOR +
+                new File(this.configuration.getAbsolutePathToProjectRoot() + fileSeparator + this.program.getTestClassesDir()).getAbsolutePath();
 
         if (this.configuration.getProperty("additionalClasspathElements") != null) {
-            classpath += PATH_SEPARATOR + new File(this.configuration.getInputProgram().getProgramDir()
-                    + this.configuration.getProperty("additionalClasspathElements")).getAbsolutePath();
+            classpath += PATH_SEPARATOR + new File(this.configuration.getAbsolutePathToProjectRoot()
+                    + this.configuration.getProperty("additionalClasspathElements"));
         }
 
         DSpotCompiler.compile(DSpotCompiler.pathToTmpTestSources, classpath,
-                new File(this.program.getProgramDir() + fileSeparator + this.program.getTestClassesDir()));
+                new File(this.configuration.getAbsolutePathToProjectRoot() + fileSeparator + this.program.getTestClassesDir()));
 
-        final String targetClasses = new File(this.program.getProgramDir() + (this.program.getProgramDir().endsWith("/") ? "" : "/") + this.program.getClassesDir()).getAbsolutePath() +
-                        AmplificationHelper.PATH_SEPARATOR +
-                        new File(this.program.getProgramDir() + (this.program.getProgramDir().endsWith("/") ? "" : "/") + this.program.getTestClassesDir()).getAbsolutePath();
+        final String targetClasses = new File(this.configuration.getAbsolutePathToProjectRoot() + (this.configuration.getAbsolutePathToProjectRoot().endsWith("/") ? "" : "/") + this.program.getClassesDir()).getAbsolutePath() +
+                AmplificationHelper.PATH_SEPARATOR +
+                new File(this.configuration.getAbsolutePathToProjectRoot() + (this.configuration.getAbsolutePathToProjectRoot().endsWith("/") ? "" : "/") + this.program.getTestClassesDir()).getAbsolutePath();
         try {
             final Coverage coverageResults = EntryPoint.runCoverageOnTestClasses(
                     classpath,

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/PitMutantScoreSelector.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/PitMutantScoreSelector.java
@@ -68,8 +68,8 @@ public class PitMutantScoreSelector extends TakeAllSelector {
         }
         if (this.originalKilledMutants == null) {
             final AutomaticBuilder automaticBuilder = AutomaticBuilderFactory.getAutomaticBuilder(this.configuration);
-            automaticBuilder.runPit(this.program.getProgramDir());
-            initOriginalPitResult(PitResultParser.parseAndDelete(this.program.getProgramDir() + automaticBuilder.getOutputDirectoryPit()) );
+            automaticBuilder.runPit(this.configuration.getAbsolutePathToProjectRoot());
+            initOriginalPitResult(PitResultParser.parseAndDelete(this.configuration.getAbsolutePathToProjectRoot() + automaticBuilder.getOutputDirectoryPit()) );
         }
     }
 
@@ -113,20 +113,20 @@ public class PitMutantScoreSelector extends TakeAllSelector {
                 .getAutomaticBuilder(this.configuration);
         final String classpath = AutomaticBuilderFactory
                 .getAutomaticBuilder(this.configuration)
-                .buildClasspath(this.program.getProgramDir())
+                .buildClasspath(this.configuration.getAbsolutePathToProjectRoot())
                 + AmplificationHelper.PATH_SEPARATOR +
-                this.program.getProgramDir() + "/" + this.program.getClassesDir()
+                this.configuration.getAbsolutePathToProjectRoot() + "/" + this.program.getClassesDir()
                 + AmplificationHelper.PATH_SEPARATOR + "target/dspot/dependencies/"
                 + AmplificationHelper.PATH_SEPARATOR +
-                this.program.getProgramDir() + "/" + this.program.getTestClassesDir();
+                this.configuration.getAbsolutePathToProjectRoot() + "/" + this.program.getTestClassesDir();
 
         DSpotCompiler.compile(DSpotCompiler.pathToTmpTestSources, classpath,
-                new File(this.program.getProgramDir() + "/" + this.program.getTestClassesDir()));
+                new File(this.configuration.getAbsolutePathToProjectRoot() + "/" + this.program.getTestClassesDir()));
 
         AutomaticBuilderFactory
                 .getAutomaticBuilder(this.configuration)
-                .runPit(this.program.getProgramDir(), clone);
-        final List<PitResult> results = PitResultParser.parseAndDelete(program.getProgramDir() + automaticBuilder.getOutputDirectoryPit());
+                .runPit(this.configuration.getAbsolutePathToProjectRoot(), clone);
+        final List<PitResult> results = PitResultParser.parseAndDelete(this.configuration.getAbsolutePathToProjectRoot() + automaticBuilder.getOutputDirectoryPit());
 
         Set<CtMethod<?>> selectedTests = new HashSet<>();
         if (results != null) {

--- a/dspot/src/main/java/eu/stamp_project/minimization/ChangeMinimizer.java
+++ b/dspot/src/main/java/eu/stamp_project/minimization/ChangeMinimizer.java
@@ -54,7 +54,7 @@ public class ChangeMinimizer extends GeneralMinimizer {
         this.failurePerAmplifiedTest = failurePerAmplifiedTest;
         this.classpath = AutomaticBuilderFactory
                 .getAutomaticBuilder(this.configuration)
-                .buildClasspath(this.program.getProgramDir())
+                .buildClasspath(this.configuration.getAbsolutePathToProjectRoot())
                 + AmplificationHelper.PATH_SEPARATOR + "target/dspot/dependencies/";
     }
 
@@ -97,7 +97,7 @@ public class ChangeMinimizer extends GeneralMinimizer {
         try {
             final TestListener result = EntryPoint.runTests(classpath +
                             AmplificationHelper.PATH_SEPARATOR +
-                            new File(this.pathToChangedVersionOfProgram + "/" + this.program.getClassesDir()).getAbsolutePath() +
+                            new File(this.configuration.getAbsolutePathToProjectRoot() + "/" + this.program.getClassesDir()).getAbsolutePath() +
                             AmplificationHelper.PATH_SEPARATOR +
                             new File(this.pathToChangedVersionOfProgram + "/" + this.program.getTestClassesDir()).getAbsolutePath(),
                     clone.getQualifiedName(),
@@ -150,11 +150,12 @@ public class ChangeMinimizer extends GeneralMinimizer {
                 .forEach(clone::removeMethod);
         clone.addMethod(amplifiedTestToBeMinimized);
         DSpotUtils.printCtTypeToGivenDirectory(clone, new File(DSpotCompiler.pathToTmpTestSources));
+        final String classes = AmplificationHelper.PATH_SEPARATOR +
+                this.configuration.getAbsolutePathToProjectRoot() + "/" + this.program.getClassesDir()
+                + AmplificationHelper.PATH_SEPARATOR +
+                this.configuration.getAbsolutePathToProjectRoot() + "/" + this.program.getTestClassesDir();
         final boolean compile = DSpotCompiler.compile(DSpotCompiler.pathToTmpTestSources,
-                classpath + AmplificationHelper.PATH_SEPARATOR +
-                        this.program.getProgramDir() + "/" + this.program.getClassesDir()
-                        + AmplificationHelper.PATH_SEPARATOR +
-                        this.program.getProgramDir() + "/" + this.program.getTestClassesDir(),
+                classpath + classes,
                 new File(this.pathToChangedVersionOfProgram + "/" + this.program.getTestClassesDir()));
         return compile;
     }

--- a/dspot/src/main/java/eu/stamp_project/utils/AmplificationHelper.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/AmplificationHelper.java
@@ -226,18 +226,18 @@ public class AmplificationHelper {
                         final CtType<?> convertedSuperclass =
                                 AmplificationHelper.convertToJUnit4(superclass, configuration, program);
                         DSpotUtils.printCtTypeToGivenDirectory(convertedSuperclass,
-                                new File(program.getProgramDir() + "/" + program.getTestClassesDir()));
+                                new File(configuration.getAbsolutePathToProjectRoot() + "/" + program.getTestClassesDir()));
                         final String classpath = AutomaticBuilderFactory
                                 .getAutomaticBuilder(configuration)
-                                .buildClasspath(program.getProgramDir())
+                                .buildClasspath(configuration.getAbsolutePathToProjectRoot())
                                 + AmplificationHelper.PATH_SEPARATOR +
-                                program.getProgramDir() + "/" + program.getClassesDir()
+                                configuration.getAbsolutePathToProjectRoot() + "/" + program.getClassesDir()
                                 + AmplificationHelper.PATH_SEPARATOR + "target/dspot/dependencies/"
                                 + AmplificationHelper.PATH_SEPARATOR +
-                                program.getProgramDir() + "/" + program.getTestClassesDir();
+                                configuration.getAbsolutePathToProjectRoot() + "/" + program.getTestClassesDir();
 
                         DSpotCompiler.compile(DSpotCompiler.pathToTmpTestSources, classpath,
-                                new File(program.getProgramDir() + "/" + program.getTestClassesDir()));
+                                new File(configuration.getAbsolutePathToProjectRoot() + "/" + program.getTestClassesDir()));
                     }
                     if (superclass.getSuperclass() == null) {
                         break;
@@ -458,7 +458,7 @@ public class AmplificationHelper {
     public static String getClassPath(DSpotCompiler compiler, InputConfiguration configuration) {
         return Arrays.stream(new String[]{
                         compiler.getBinaryOutputDirectory().getAbsolutePath(),
-                        new File(configuration.getInputProgram().getProgramDir() + "/" + configuration.getInputProgram().getClassesDir()).getAbsolutePath(),
+                        new File(configuration.getAbsolutePathToProjectRoot() + "/" + configuration.getInputProgram().getClassesDir()).getAbsolutePath(),
                         compiler.getDependencies(),
                 }
         ).collect(Collectors.joining(PATH_SEPARATOR));

--- a/dspot/src/main/java/eu/stamp_project/utils/DSpotUtils.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/DSpotUtils.java
@@ -30,156 +30,153 @@ import java.util.stream.Collectors;
  * User: Simon Date: 18/05/16 Time: 16:10
  */
 public class DSpotUtils {
+	
+    public static boolean withComment = false;
 
-	public static boolean withComment = false;
+    private static final Logger LOGGER = LoggerFactory.getLogger(DSpotUtils.class);
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(DSpotUtils.class);
+    private static StringBuilder progress = new StringBuilder(60);
 
-	private static StringBuilder progress = new StringBuilder(60);
+    public static void printProgress(int done, int total) {
+        char[] workchars = {'|', '/', '-', '\\'};
+        String format = "\r%3d%% |%s ]%c";
+        int percent = (++done * 100) / total;
+        int extrachars = (percent / 2) - progress.length();
+        while (extrachars-- > 0) {
+            progress.append('=');
+        }
+        System.out.printf(format, percent, progress, workchars[done % workchars.length]);
+        if (done == total) {
+            System.out.flush();
+            System.out.println();
+            progress = new StringBuilder(60);
+        }
+    }
 
-	public static void printProgress(int done, int total) {
-		char[] workchars = { '|', '/', '-', '\\' };
-		String format = "\r%3d%% |%s ]%c";
-		int percent = (++done * 100) / total;
-		int extrachars = (percent / 2) - progress.length();
-		while (extrachars-- > 0) {
-			progress.append('=');
-		}
-		System.out.printf(format, percent, progress, workchars[done % workchars.length]);
-		if (done == total) {
-			System.out.flush();
-			System.out.println();
-			progress = new StringBuilder(60);
-		}
-	}
+    public static String[] getAllTestClasses(InputConfiguration configuration) {
+        return configuration.getFactory().Class().getAll().stream()
+                .filter(ctType -> ctType.getMethods().stream().anyMatch(AmplificationChecker::isTest))
+                .map(CtType::getQualifiedName).toArray(String[]::new);
+    }
 
-	public static String[] getAllTestClasses(InputConfiguration configuration) {
-		return configuration.getFactory().Class().getAll().stream()
-				.filter(ctType -> ctType.getMethods().stream().anyMatch(AmplificationChecker::isTest))
-				.map(CtType::getQualifiedName).toArray(String[]::new);
-	}
+    public static void printCtTypeToGivenDirectory(CtType<?> type, File directory) {
+        Factory factory = type.getFactory();
+        Environment env = factory.getEnvironment();
+        env.setAutoImports(true);
+        env.setCommentEnabled(withComment);
+        JavaOutputProcessor processor = new JavaOutputProcessor(new DefaultJavaPrettyPrinter(env));
+        processor.setFactory(factory);
+        processor.setOutputDirectory(directory);
+        processor.createJavaFile(type);
+        env.setAutoImports(false);
+    }
 
-	public static void printCtTypeToGivenDirectory(CtType<?> type, File directory) {
-		Factory factory = type.getFactory();
-		Environment env = factory.getEnvironment();
-		env.setAutoImports(true);
-		env.setCommentEnabled(withComment);
-		JavaOutputProcessor processor = new JavaOutputProcessor(new DefaultJavaPrettyPrinter(env));
-		processor.setFactory(factory);
-		processor.setOutputDirectory(directory);
-		processor.createJavaFile(type);
-		env.setAutoImports(false);
-	}
+    public static void printAmplifiedTestClass(CtType<?> type, File directory) {
+        final String pathname = directory.getAbsolutePath() + "/" + type.getQualifiedName().replaceAll("\\.", "/")
+                + ".java";
+        if (new File(pathname).exists()) {
+            printCtTypeToGivenDirectory(addGeneratedTestToExistingClass(type, pathname), directory);
+        } else {
+            printCtTypeToGivenDirectory(type, directory);
+        }
+    }
 
-	public static void printAmplifiedTestClass(CtType<?> type, File directory) {
-		final String pathname = directory.getAbsolutePath() + "/" + type.getQualifiedName().replaceAll("\\.", "/")
-				+ ".java";
-		if (new File(pathname).exists()) {
-			printCtTypeToGivenDirectory(addGeneratedTestToExistingClass(type, pathname), directory);
-		} else {
-			printCtTypeToGivenDirectory(type, directory);
-		}
-	}
+    private static CtClass<?> addGeneratedTestToExistingClass(CtType<?> type, String pathname) {
+        Launcher launcher = new Launcher();
+        launcher.getEnvironment().setNoClasspath(true);
+        launcher.addInputResource(pathname);
+        launcher.buildModel();
+        final CtClass<?> existingAmplifiedTest = launcher.getFactory().Class().get(type.getQualifiedName());
+        type.getMethods().stream().filter(testCase -> !existingAmplifiedTest.getMethods().contains(testCase))
+                .forEach(existingAmplifiedTest::addMethod);
+        return existingAmplifiedTest;
+    }
 
-	private static CtClass<?> addGeneratedTestToExistingClass(CtType<?> type, String pathname) {
-		Launcher launcher = new Launcher();
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.addInputResource(pathname);
-		launcher.buildModel();
-		final CtClass<?> existingAmplifiedTest = launcher.getFactory().Class().get(type.getQualifiedName());
-		type.getMethods().stream().filter(testCase -> !existingAmplifiedTest.getMethods().contains(testCase))
-				.forEach(existingAmplifiedTest::addMethod);
-		return existingAmplifiedTest;
-	}
+    public static void printAllClasses(Factory factory, File out) {
+        factory.Class().getAll().forEach(type -> printCtTypeToGivenDirectory(type, out));
+    }
 
-	public static void printAllClasses(Factory factory, File out) {
-		factory.Class().getAll().forEach(type -> printCtTypeToGivenDirectory(type, out));
-	}
+    public static void addComment(CtElement element, String content, CtComment.CommentType type) {
+        CtComment comment = element.getFactory().createComment(content, type);
+        if (!element.getComments().contains(comment)) {
+            element.addComment(comment);
+        }
+    }
 
-	public static void addComment(CtElement element, String content, CtComment.CommentType type) {
-		CtComment comment = element.getFactory().createComment(content, type);
-		if (!element.getComments().contains(comment)) {
-			element.addComment(comment);
-		}
-	}
+    public static String mavenHome;
 
-	public static String mavenHome;
+    public static String buildMavenHome(InputConfiguration inputConfiguration) {
+        if (mavenHome == null) {
+            if (inputConfiguration != null && inputConfiguration.getProperty("maven.home") != null) {
+                mavenHome = inputConfiguration.getProperty("maven.home");
+            } else {
+                if (!setMavenHome(envVariable -> System.getenv().get(envVariable) != null,
+                        envVariable -> System.getenv().get(envVariable), "MAVEN_HOME", "M2_HOME")) {// TODO asking if
+                    // predefined values
+                    // are useful or not
+                    if (!setMavenHome(path -> new File(path).exists(), Function.identity(), "/usr/share/maven/",
+                            "/usr/local/maven-3.3.9/", "/usr/share/maven3/")) {
+                        throw new RuntimeException("Maven home not found, please set properly MAVEN_HOME or M2_HOME.");
+                    }
+                }
+            }
+        }
+        return mavenHome;
+    }
 
-	public static String buildMavenHome(InputConfiguration inputConfiguration) {
-		if (mavenHome == null) {
-			if (inputConfiguration != null && inputConfiguration.getProperty("maven.home") != null) {
-				mavenHome = inputConfiguration.getProperty("maven.home");
-			} else {
-				if (!setMavenHome(envVariable -> System.getenv().get(envVariable) != null,
-						envVariable -> System.getenv().get(envVariable), "MAVEN_HOME", "M2_HOME")) {// TODO asking if
-																									// predefined values
-																									// are useful or not
-					if (!setMavenHome(path -> new File(path).exists(), Function.identity(), "/usr/share/maven/",
-							"/usr/local/maven-3.3.9/", "/usr/share/maven3/")) {
-						throw new RuntimeException("Maven home not found, please set properly MAVEN_HOME or M2_HOME.");
-					}
-				}
-			}
-		}
-		return mavenHome;
-	}
+    private static boolean setMavenHome(Predicate<String> conditional, Function<String, String> getFunction,
+                                        String... possibleValues) {
+        Arrays.stream(possibleValues).filter(conditional).findFirst().ifPresent(s -> mavenHome = getFunction.apply(s));
+        return mavenHome != null;
+    }
 
-	private static boolean setMavenHome(Predicate<String> conditional, Function<String, String> getFunction,
-			String... possibleValues) {
-		Arrays.stream(possibleValues).filter(conditional).findFirst().ifPresent(s -> mavenHome = getFunction.apply(s));
-		return mavenHome != null;
-	}
+    public static final String pathToDSpotDependencies = "target/dspot/dependencies/";
 
-	public static final String pathToDSpotDependencies = "target/dspot/dependencies/";
+    public static final String packagePath = "eu/stamp_project/compare/";
 
-	public static final String packagePath = "eu/stamp_project/compare/";
+    public static final String[] classesToCopy = new String[]{"MethodsHandler", "ObjectLog", "Observation", "Utils", "FailToObserveException"};
 
-	public static final String[] classesToCopy = new String[]{"MethodsHandler", "ObjectLog", "Observation", "Utils", "FailToObserveException"};
+    public static void copyPackageFromResources() {
+        final String pathToTestClassesDirectory = pathToDSpotDependencies + "/" + packagePath + "/";
+        final String directory = packagePath.split("/")[packagePath.split("/").length - 1];
+        try {
+            FileUtils.forceMkdir(new File(pathToTestClassesDirectory));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        Arrays.stream(classesToCopy).forEach(file -> {
+            OutputStream resStreamOut = null;
+            try {
+                final InputStream resourceAsStream = Thread.currentThread().getContextClassLoader()
+                        .getResourceAsStream(directory + "/" + file + ".class");
+                resStreamOut = new FileOutputStream(pathToTestClassesDirectory + file + ".class");
+                int readBytes;
+                byte[] buffer = new byte[4096];
+                while ((readBytes = resourceAsStream.read(buffer)) > 0) {
+                    resStreamOut.write(buffer, 0, readBytes);
+                }
+                resStreamOut.close();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
 
-	public static void copyPackageFromResources() {
-		if (new File("target/dspot/dependencies/eu/stamp_project/compare").exists()) {
-			return;
-		}
-		final String pathToTestClassesDirectory = pathToDSpotDependencies + "/" + packagePath + "/";
-		final String directory = packagePath.split("/")[packagePath.split("/").length - 1];
-		try {
-			FileUtils.forceMkdir(new File(pathToTestClassesDirectory));
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-		Arrays.stream(classesToCopy).forEach(file -> {
-			OutputStream resStreamOut = null;
-			try {
-				final InputStream resourceAsStream = Thread.currentThread().getContextClassLoader()
-						.getResourceAsStream(directory + "/" + file + ".class");
-				resStreamOut = new FileOutputStream(pathToTestClassesDirectory + file + ".class");
-				int readBytes;
-				byte[] buffer = new byte[4096];
-				while ((readBytes = resourceAsStream.read(buffer)) > 0) {
-					resStreamOut.write(buffer, 0, readBytes);
-				}
-				resStreamOut.close();
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-		});
-	}
+    public static final Function<String, String> shouldAddSeparator = string -> string.endsWith("/") ? "" : "/";
 
-	public static final Function<String, String> shouldAddSeparator = string -> string.endsWith("/") ? "" : "/";
+    public static Function<InputConfiguration, String> computeProgramDirectory = configuration -> new File(
+            configuration.getProperty("project") + shouldAddSeparator.apply(configuration.getProperty("project"))
+                    + (configuration.getProperty("targetModule") != null ? configuration.getProperty("targetModule")
+                    + shouldAddSeparator.apply(configuration.getProperty("targetModule")) : "")).getAbsolutePath();
 
-	public static Function<InputConfiguration, String> computeProgramDirectory = configuration -> configuration
-			.getProperty("project") + shouldAddSeparator.apply(configuration.getProperty("project"))
-			+ (configuration.getProperty("targetModule") != null ? configuration.getProperty("targetModule")
-					+ shouldAddSeparator.apply(configuration.getProperty("targetModule")) : "");
-
-	public static String ctTypeToFullQualifiedName(CtType<?> testClass) {
-		if (testClass.getModifiers().contains(ModifierKind.ABSTRACT)) {
-			CtTypeReference<?> referenceOfSuperClass = testClass.getReference();
-			return testClass.getFactory().Class().getAll().stream()
-					.filter(ctType -> referenceOfSuperClass.equals(ctType.getSuperclass()))
-					.map(CtType::getQualifiedName).collect(Collectors.joining(","));
-		} else {
-			return testClass.getQualifiedName();
-		}
-	}
+    public static String ctTypeToFullQualifiedName(CtType<?> testClass) {
+        if (testClass.getModifiers().contains(ModifierKind.ABSTRACT)) {
+            CtTypeReference<?> referenceOfSuperClass = testClass.getReference();
+            return testClass.getFactory().Class().getAll().stream()
+                    .filter(ctType -> referenceOfSuperClass.equals(ctType.getSuperclass()))
+                    .map(CtType::getQualifiedName).collect(Collectors.joining(","));
+        } else {
+            return testClass.getQualifiedName();
+        }
+    }
 }

--- a/dspot/src/main/java/eu/stamp_project/utils/DSpotUtils.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/DSpotUtils.java
@@ -54,7 +54,7 @@ public class DSpotUtils {
 	}
 
 	public static String[] getAllTestClasses(InputConfiguration configuration) {
-		return configuration.getInputProgram().getFactory().Class().getAll().stream()
+		return configuration.getFactory().Class().getAll().stream()
 				.filter(ctType -> ctType.getMethods().stream().anyMatch(AmplificationChecker::isTest))
 				.map(CtType::getQualifiedName).toArray(String[]::new);
 	}

--- a/dspot/src/main/java/eu/stamp_project/utils/DSpotUtils.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/DSpotUtils.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
  * User: Simon Date: 18/05/16 Time: 16:10
  */
 public class DSpotUtils {
-	
+
     public static boolean withComment = false;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DSpotUtils.class);

--- a/dspot/src/main/java/eu/stamp_project/utils/Initializer.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/Initializer.java
@@ -31,17 +31,18 @@ public class Initializer {
 	public static void initialize(InputConfiguration configuration, InputProgram program) {
 		AutomaticBuilderFactory.reset();
 		AutomaticBuilder builder = AutomaticBuilderFactory.getAutomaticBuilder(configuration);
-		builder.compile(program.getProgramDir());
+		builder.compile(configuration.getAbsolutePathToProjectRoot());
 		DSpotUtils.copyPackageFromResources();
 	}
 
+	@Deprecated
 	public static void compileTest(InputConfiguration configuration) {
 		InputProgram program = configuration.getInputProgram();
 		String dependencies = AutomaticBuilderFactory.getAutomaticBuilder(configuration)
-				.buildClasspath(program.getProgramDir());
+				.buildClasspath(configuration.getAbsolutePathToProjectRoot());
 		dependencies += PATH_SEPARATOR + "target/dspot/dependencies/";
-		File output = new File(program.getProgramDir() + "/" + program.getClassesDir());
-		File outputTest = new File(program.getProgramDir() + "/" + program.getTestClassesDir());
+		File output = new File(configuration.getAbsolutePathToProjectRoot() + "/" + program.getClassesDir());
+		File outputTest = new File(configuration.getAbsolutePathToProjectRoot() + "/" + program.getTestClassesDir());
 		try {
 			FileUtils.cleanDirectory(outputTest);
 		} catch (Exception ignored) {

--- a/dspot/src/main/java/eu/stamp_project/utils/Initializer.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/Initializer.java
@@ -22,6 +22,7 @@ public class Initializer {
 	public static void initialize(InputConfiguration configuration)
 			throws IOException, InterruptedException {
 		InputProgram program = InputConfiguration.initInputProgram(configuration);
+		configuration.setAbsolutePathToProjectRoot(DSpotUtils.computeProgramDirectory.apply(configuration));
 		program.setProgramDir(DSpotUtils.computeProgramDirectory.apply(configuration));
 		configuration.setInputProgram(program);
 		Initializer.initialize(configuration, program);

--- a/dspot/src/main/java/eu/stamp_project/utils/compilation/DSpotCompiler.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/compilation/DSpotCompiler.java
@@ -1,13 +1,18 @@
 package eu.stamp_project.utils.compilation;
 
-import eu.stamp_project.utils.DSpotUtils;
-import eu.stamp_project.utils.sosiefier.InputProgram;
 import eu.stamp_project.Main;
+import eu.stamp_project.utils.DSpotUtils;
+import eu.stamp_project.utils.sosiefier.InputConfiguration;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import spoon.Launcher;
 import spoon.OutputType;
 import spoon.SpoonModelBuilder;
-import spoon.compiler.builder.*;
+import spoon.compiler.builder.AdvancedOptions;
+import spoon.compiler.builder.AnnotationProcessingOptions;
+import spoon.compiler.builder.ClasspathOptions;
+import spoon.compiler.builder.ComplianceOptions;
+import spoon.compiler.builder.JDTBuilderImpl;
+import spoon.compiler.builder.SourceOptions;
 import spoon.support.compiler.FileSystemFolder;
 import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
 
@@ -26,17 +31,19 @@ public class DSpotCompiler extends JDTBasedSpoonCompiler {
 
 	public static final String pathToTmpTestSources = "target/dspot/tmp_test_sources";
 
-	public static DSpotCompiler createDSpotCompiler(InputProgram program, String pathToDependencies) {
-		String pathToSources = program.getAbsoluteSourceCodeDir() + PATH_SEPARATOR + program.getAbsoluteTestSourceCodeDir();
+	public static DSpotCompiler createDSpotCompiler(InputConfiguration configuration, String pathToDependencies) {
+		String pathToSources = configuration.getInputProgram().getAbsoluteSourceCodeDir() + PATH_SEPARATOR +
+				configuration.getInputProgram().getAbsoluteTestSourceCodeDir();
 		Launcher launcher = getSpoonModelOf(pathToSources, pathToDependencies);
-		return new DSpotCompiler(launcher, program, pathToDependencies);
+		return new DSpotCompiler(launcher, configuration, pathToDependencies);
 	}
 
-	private DSpotCompiler(Launcher launcher, InputProgram program, String pathToDependencies) {
+	private DSpotCompiler(Launcher launcher, InputConfiguration configuration, String pathToDependencies) {
 		super(launcher.getFactory());
 		this.dependencies = pathToDependencies;
 		this.launcher = launcher;
-		this.binaryOutputDirectory = new File(program.getProgramDir() + "/" + program.getTestClassesDir());
+		this.binaryOutputDirectory = new File(configuration.getAbsolutePathToProjectRoot() + "/" +
+				configuration.getInputProgram().getTestClassesDir());
 		this.sourceOutputDirectory = new File(pathToTmpTestSources);
 		if (!this.sourceOutputDirectory.exists()) {
 			this.sourceOutputDirectory.mkdir();

--- a/dspot/src/main/java/eu/stamp_project/utils/compilation/TestCompiler.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/compilation/TestCompiler.java
@@ -61,9 +61,9 @@ public class TestCompiler {
                                              List<CtMethod<?>> testsToRun,
                                              InputConfiguration configuration) throws AmplificationException {
         final InputProgram inputProgram = configuration.getInputProgram();
-        final String dependencies = inputProgram.getProgramDir() + "/" + inputProgram.getClassesDir() +
+        final String dependencies = configuration.getAbsolutePathToProjectRoot()+ "/" + inputProgram.getClassesDir() +
                 System.getProperty("path.separator") +
-                inputProgram.getProgramDir() + "/" + inputProgram.getTestClassesDir() +
+                configuration.getAbsolutePathToProjectRoot() + "/" + inputProgram.getTestClassesDir() +
                 System.getProperty("path.separator") + "target/dspot/dependencies/";
         DSpotUtils.copyPackageFromResources();
         final List<CtMethod<?>> uncompilableMethods =

--- a/dspot/src/main/java/eu/stamp_project/utils/sosiefier/InputConfiguration.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/sosiefier/InputConfiguration.java
@@ -1,5 +1,7 @@
 package eu.stamp_project.utils.sosiefier;
 
+import spoon.reflect.factory.Factory;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -403,4 +405,19 @@ public class InputConfiguration {
 		toReturn += "ValidationErrors: " + this.getValidationErrors();
 		return toReturn;
     }
+
+    private Factory factory;
+
+    /**
+     * Spoon factory to process all AST elements
+     */
+    public Factory getFactory() {
+        return factory;
+    }
+
+    public void setFactory(Factory factory) {
+        this.factory = factory;
+    }
+
+
 }

--- a/dspot/src/main/java/eu/stamp_project/utils/sosiefier/InputConfiguration.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/sosiefier/InputConfiguration.java
@@ -274,6 +274,6 @@ public class InputConfiguration {
     }
 
     public void setAbsolutePathToProjectRoot(String absolutePathToProjectRoot) {
-        this.absolutePathToProjectRoot = absolutePathToProjectRoot;
+        this.absolutePathToProjectRoot = absolutePathToProjectRoot + DSpotUtils.shouldAddSeparator.apply(absolutePathToProjectRoot);
     }
 }

--- a/dspot/src/main/java/eu/stamp_project/utils/sosiefier/InputConfiguration.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/sosiefier/InputConfiguration.java
@@ -8,9 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -28,10 +26,6 @@ import java.util.stream.Collectors;
 //TODO @Deprecated
 public class InputConfiguration {
 
-    //GENERATOR VERSIONS
-    public static final String GEN_VERSION_1_0_0 = "1.0.0";
-    public static final String LATEST_GENERATOR_VERSION = GEN_VERSION_1_0_0;
-
     /**
      * Internal properties
      */
@@ -40,36 +34,18 @@ public class InputConfiguration {
     /**
      * resulting input program from the input configuration
      */
+    @Deprecated
     private InputProgram inputProgram;
-
-    /*
-     * Output path to all operations resulting in output
-     */
-    //private String outputPath;
-
-    /**
-     * Errors raised during validation
-     */
-    private List<String> errors;
-
-    private String rootPath;
-
 
     public InputConfiguration() {
         prop = new Properties();
         setDefaultProperties();
-        setCodeFragmentClass();
-        errors = new ArrayList<>();
-        rootPath = prop.getProperty("root.path");
     }
 
     public InputConfiguration(InputStream stream) throws IOException {
         prop = new Properties();
         setDefaultProperties();
         prop.load(stream);
-        setCodeFragmentClass();
-        errors = new ArrayList<>();
-        rootPath = prop.getProperty("root.path");
         if (prop.getProperty("systemProperties") != null) {
             Arrays.stream(prop.getProperty("systemProperties").split(","))
                     .forEach( systemProperty -> {
@@ -94,7 +70,6 @@ public class InputConfiguration {
 			getProperties().setProperty("filter", filter);
 		}
 		getProperties().setProperty("javaVersion", "8");
-		rootPath = project.getAbsolutePath();
 	}
 
     private String getRelativePath(File path) {
@@ -105,9 +80,6 @@ public class InputConfiguration {
 
     public InputConfiguration(String file) throws IOException {
         this(new FileInputStream(file));
-        if (rootPath == null || rootPath.equals("")) {
-            rootPath = System.getProperty("user.dir");
-        }
     }
 
     /**
@@ -143,6 +115,7 @@ public class InputConfiguration {
     /**
      * The input program we are sosieficating.
      */
+    @Deprecated
     public InputProgram getInputProgram() {
         return inputProgram;
     }
@@ -150,6 +123,7 @@ public class InputConfiguration {
     /**
      * The input program we are sosieficating.
      */
+    @Deprecated
     public void setInputProgram(InputProgram inputProgram) {
         this.inputProgram = inputProgram;
     }
@@ -183,32 +157,12 @@ public class InputConfiguration {
 
 
     /**
-     * Returns the path of the previously found transformations
-     *
-     * @return
-     */
-    public String getPreviousTransformationPath() {
-        String s = prop.getProperty("transformation.directory", "");
-        return getAbsolutePath(s);
-    }
-
-    /**
      * Returns the path of the built classes
      *
      * @return String with the path
      */
     public String getClassesDir() {
         return  prop.getProperty("classes");
-    }
-
-    /**
-     * Get coverage dir of a project
-     *
-     * @return
-     */
-    public String getCoverageDir() {
-        String s = prop.getProperty("jacoco") == null ? prop.getProperty("coverage", "") : prop.getProperty("jacoco");
-        return getAbsolutePath(s);
     }
 
     /**
@@ -219,87 +173,15 @@ public class InputConfiguration {
         return prop.getProperty("outputDirectory", "output");
     }
 
-    /**
-     * If some path is given as relative path, this root will be used to resolve it
-     */
-    public String getRootPath() {
-        return rootPath;
-    }
-
-    /**
-     * Errors found during the validation
-     *
-     * @return A collection of messages of errors found during the validation
-     */
-    public Collection<String> getValidationErrors() {
-        return errors;
-    }
-
-  /*  *//**
-     * Returns a new code fragment given the processing level set by the user in the input properties
-     * <p>
-     * Defaults to statement in case of any error
-     *
-     * @return
-     *//*
-    public CodeFragment getNewCodeFragment() {
-        CodeFragment result;
-        try {
-            Class cl = Class.forName(getProperties().getProperty("CodeFragmentClass"));
-            result = (CodeFragment) cl.newInstance();
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
-            result = new Statement();
-            Log.warn("Unable to create the code fragment requested, resolved to Statement level", e);
-            e.printStackTrace();
-        }
-        return result;
-    }*/
-
-    protected void setCodeFragmentClass() {
-        if (getProperties().getProperty("processor").equals("eu.stamp_project.diversify.codeFragmentProcessor.StatementProcessor")) {
-            getProperties().setProperty("CodeFragmentClass", "eu.stamp_project.diversify.codeFragment.Statement");
-        }
-        if (getProperties().getProperty("processor").equals("eu.stamp_project.diversify.codeFragmentProcessor.ExpressionProcessor")) {
-            getProperties().setProperty("CodeFragmentClass", "eu.stamp_project.diversify.codeFragment.Expression");
-        }
-        if (getProperties().getProperty("processor").equals("eu.stamp_project.diversify.codeFragmentProcessor.BlockProcessor")) {
-            getProperties().setProperty("CodeFragmentClass", "eu.stamp_project.diversify.codeFragment.Block");
-        }
-    }
-
     protected void setDefaultProperties() {
         prop.setProperty("src", "src/main/java");
         prop.setProperty("testSrc", "src/test/java");
         prop.setProperty("classes", "target/classes");
-        prop.setProperty("clojure", "false");
         prop.setProperty("javaVersion", "5");
-        prop.setProperty("transformation.type", "all");
-        prop.setProperty("transformation.size", "1");
-        prop.setProperty("stat", "false");
-        prop.setProperty("sosie", "false");
-
-        //Indicates if the Diversify must report early
-        prop.setProperty("early.report", "0");
-
-        //temporary directory
-        prop.setProperty("tmpDir", "tmpDir");
-
-        //directory for output
+        prop.setProperty("tmpDir", "tmpDir"); // TODO Checks usage
         prop.setProperty("outputDirectory", "output");
-
-        prop.setProperty("sosieOnMultiProject", "false");
-        prop.setProperty("timeOut", "-1");
-        prop.setProperty("logLevel", "2");
-        prop.setProperty("gitRepository", "null");
-        prop.setProperty("processor", "eu.stamp_project.diversify.codeFragmentProcessor.StatementProcessor");
-        prop.setProperty("transplant.point.search.strategy",
-                "eu.stamp_project.diversify.transformation.executeQuery.searchStrategy.SimpleRandomStrategy");
-        prop.setProperty("transplant.search.strategy",
-                "eu.stamp_project.diversify.transformation.executeQuery.searchStrategy.SimpleRandomStrategy");
-
-        prop.setProperty("syncroRange", "0");
-        prop.setProperty("maven.newPomFile", "");
-        prop.setProperty("transformation.level", "statement");
+        prop.setProperty("timeOut", "-1"); // TODO Checks usage
+        prop.setProperty("logLevel", "2"); // TODO Checks usage
         prop.setProperty("builder", "maven");
         prop.setProperty("pom", "/pom.xml");
     }
@@ -309,40 +191,7 @@ public class InputConfiguration {
         if ( new File(path).exists() || p.isAbsolute() ) {
             return path;
         }
-        if (rootPath != null && !rootPath.equals("")) {
-            p = Paths.get(rootPath + "/" + path);
-        } else {
-            p = Paths.get(path);
-        }
         return p.normalize().toString().replace(File.separator, "/");
-    }
-
-
-    private void addError(String error) {
-        errors.add(error);
-    }
-
-    private void checkPath(String desc, String path, boolean mustExist) {
-        if (path == null) {
-            if (mustExist) {
-                addError(desc + " at " + path + " does not exists");
-            }
-        } else if (!new File(path).exists() && (mustExist || !path.equals(""))) {
-            addError(desc + " at " + path + " does not exists");
-        }
-    }
-
-    /**
-     * Checks that the configuration is valid
-     */
-    public boolean validate() {
-        checkPath("Project path", getProjectPath(), true);
-        checkPath("Source path", getProjectPath() + "/"+ getOutputDirectory() , true);
-        checkPath("Previous transformation path", getPreviousTransformationPath(), false);
-        checkPath("Coverage dir", getCoverageDir(), false);
-        checkPath("Root dir", getRootPath(), false);
-        checkPath("Temp directory", getTempDir(), false);
-        return errors.size() == 0;
     }
 
     /**
@@ -394,15 +243,11 @@ public class InputConfiguration {
 			toReturn += key + ": " + prop.getProperty((String) key)+ "\n";
 		}
 		toReturn += "ClassesDir: " + this.getClassesDir()+ "\n";
-		toReturn += "coverageDir: " + this.getCoverageDir()+ "\n";
 		toReturn += "outputDirectory: " + this.getOutputDirectory()+ "\n";
-		toReturn += "previousTransformationPath: " + this.getPreviousTransformationPath()+ "\n";
 		toReturn += "projectPath: " + this.getProjectPath()+ "\n";
 		toReturn += "relativeSourceCodeDir: " + this.getRelativeSourceCodeDir()+ "\n";
 		toReturn += "relativeTestSourceCodeDir: " + this.getRelativeTestSourceCodeDir()+ "\n";
-		toReturn += "RootPath: " + this.getRootPath()+ "\n";
 		toReturn += "TempDir: " + this.getTempDir()+ "\n";
-		toReturn += "ValidationErrors: " + this.getValidationErrors();
 		return toReturn;
     }
 

--- a/dspot/src/main/java/eu/stamp_project/utils/sosiefier/InputConfiguration.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/sosiefier/InputConfiguration.java
@@ -1,5 +1,6 @@
 package eu.stamp_project.utils.sosiefier;
 
+import eu.stamp_project.utils.DSpotUtils;
 import spoon.reflect.factory.Factory;
 
 import java.io.File;
@@ -15,12 +16,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * The input configuration class encapsulates all the data and asociated behavior we obtain from the input properties
+ * The input configuration class encapsulates all the data and associated behavior we obtain from the input properties
  * given by the user.
- * <p>
- * The InputConfiguration makes other objects life easier by not only being a data holder but also by implementing
- * behaviors related from this data as the building of new CodeFragments given the CodeFragmentClass property
- * <p>
  * Created by marcel on 8/06/14.
  */
 //TODO @Deprecated
@@ -53,6 +50,7 @@ public class InputConfiguration {
                                 System.getProperties().put(keyValueInArray[0], keyValueInArray[1]);
                             });
         }
+        this.absolutePathToProjectRoot = DSpotUtils.computeProgramDirectory.apply(this);
     }
 
     public InputConfiguration(File project, File srcDir, File testDir, File classesDir, File testClassesDir,
@@ -264,5 +262,18 @@ public class InputConfiguration {
         this.factory = factory;
     }
 
+    private String absolutePathToProjectRoot;
 
+    /**
+     * This method return the absolute path to the project.
+     * If the project is multi-modules, the returned path is the path to the specified targetModule properties
+     * @return absolute path to the project root
+     */
+    public String getAbsolutePathToProjectRoot() {
+        return absolutePathToProjectRoot;
+    }
+
+    public void setAbsolutePathToProjectRoot(String absolutePathToProjectRoot) {
+        this.absolutePathToProjectRoot = absolutePathToProjectRoot;
+    }
 }

--- a/dspot/src/main/java/eu/stamp_project/utils/sosiefier/InputProgram.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/sosiefier/InputProgram.java
@@ -97,9 +97,7 @@ public class InputProgram {
         setRelativeSourceCodeDir(configuration.getRelativeSourceCodeDir());
         setProgramDir(configuration.getProjectPath());
         setRelativeSourceCodeDir(configuration.getRelativeSourceCodeDir());
-        setPreviousTransformationsPath(configuration.getPreviousTransformationPath());
         setClassesDir(configuration.getClassesDir());
-        setCoverageDir(configuration.getCoverageDir());
     }
 
     /**

--- a/dspot/src/main/java/eu/stamp_project/utils/sosiefier/InputProgram.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/sosiefier/InputProgram.java
@@ -3,7 +3,6 @@ package eu.stamp_project.utils.sosiefier;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.factory.Factory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -89,13 +88,6 @@ public class InputProgram {
      */
     protected List<CtLocalVariable> inlineConstant;
 
-
-    /**
-     * Spoon factory to process all AST elements
-     */
-    private Factory factory;
-
-
     /**
      * Copies properties from the configuration
      *
@@ -108,17 +100,6 @@ public class InputProgram {
         setPreviousTransformationsPath(configuration.getPreviousTransformationPath());
         setClassesDir(configuration.getClassesDir());
         setCoverageDir(configuration.getCoverageDir());
-    }
-
-    /**
-     * Spoon factory to process all AST elements
-     */
-    public Factory getFactory() {
-        return factory;
-    }
-
-    public void setFactory(Factory factory) {
-        this.factory = factory;
     }
 
     /**

--- a/dspot/src/test/java/eu/stamp_project/AbstractTest.java
+++ b/dspot/src/test/java/eu/stamp_project/AbstractTest.java
@@ -20,5 +20,6 @@ public abstract class AbstractTest {
         Utils.init(getPathToPropertiesFile());
         AmplificationHelper.setSeedRandom(72L);
         ValueCreator.count = 0;
+        AmplificationHelper.minimize = false;
     }
 }

--- a/dspot/src/test/java/eu/stamp_project/Utils.java
+++ b/dspot/src/test/java/eu/stamp_project/Utils.java
@@ -94,7 +94,7 @@ public class Utils {
 						+ inputConfiguration.getProperty("additionalClasspathElements");
 			}
 			compiler = DSpotCompiler.createDSpotCompiler(inputProgram, dependencies);
-			inputProgram.setFactory(compiler.getLauncher().getFactory());
+			inputConfiguration.setFactory(compiler.getLauncher().getFactory());
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
@@ -105,7 +105,7 @@ public class Utils {
 	}
 
 	public static CtClass findClass(String fullQualifiedName) {
-		return getInputProgram().getFactory().Class().get(fullQualifiedName);
+		return getInputConfiguration().getFactory().Class().get(fullQualifiedName);
 	}
 
 	public static CtMethod findMethod(CtClass<?> ctClass, String methodName) {
@@ -145,7 +145,7 @@ public class Utils {
 	}
 
 	public static Factory getFactory() {
-		return getInputProgram().getFactory();
+		return getInputConfiguration().getFactory();
 	}
 
 	public static final class FILTER_LITERAL_OF_GIVEN_TYPE extends TypeFilter<CtLiteral> {

--- a/dspot/src/test/java/eu/stamp_project/Utils.java
+++ b/dspot/src/test/java/eu/stamp_project/Utils.java
@@ -88,12 +88,12 @@ public class Utils {
 			Initializer.initialize(inputConfiguration);
 			inputProgram = inputConfiguration.getInputProgram();
 			builder = AutomaticBuilderFactory.getAutomaticBuilder(inputConfiguration);
-			String dependencies = builder.buildClasspath(inputProgram.getProgramDir());
+			String dependencies = builder.buildClasspath(inputConfiguration.getAbsolutePathToProjectRoot());
 			if (inputConfiguration.getProperty("additionalClasspathElements") != null) {
-				dependencies += PATH_SEPARATOR + inputConfiguration.getInputProgram().getProgramDir()
+				dependencies += PATH_SEPARATOR + inputConfiguration.getAbsolutePathToProjectRoot()
 						+ inputConfiguration.getProperty("additionalClasspathElements");
 			}
-			compiler = DSpotCompiler.createDSpotCompiler(inputProgram, dependencies);
+			compiler = DSpotCompiler.createDSpotCompiler(inputConfiguration, dependencies);
 			inputConfiguration.setFactory(compiler.getLauncher().getFactory());
 		} catch (Exception e) {
 			throw new RuntimeException(e);

--- a/dspot/src/test/java/eu/stamp_project/automaticbuilder/GradleAutomaticBuilderTest.java
+++ b/dspot/src/test/java/eu/stamp_project/automaticbuilder/GradleAutomaticBuilderTest.java
@@ -107,7 +107,7 @@ public class GradleAutomaticBuilderTest {
     public void runPit_whenTestClassIsSpecified() throws Exception {
         Utils.LOGGER.info("Starting Gradle Automatic Builder runPit() test when a test class is specified...");
 
-        CtClass<Object> testClass = Utils.getInputProgram().getFactory().Class().get("example.TestSuiteExample");
+        CtClass<Object> testClass = Utils.getInputConfiguration().getFactory().Class().get("example.TestSuiteExample");
 
         sut.runPit("src/test/resources/test-projects/", testClass);
         List<PitResult> pitResults = PitResultParser.parseAndDelete("src/test/resources/test-projects/"+ sut.getOutputDirectoryPit());

--- a/dspot/src/test/java/eu/stamp_project/automaticbuilder/GradleAutomaticBuilderWithDescartesTest.java
+++ b/dspot/src/test/java/eu/stamp_project/automaticbuilder/GradleAutomaticBuilderWithDescartesTest.java
@@ -64,7 +64,7 @@ public class GradleAutomaticBuilderWithDescartesTest {
     public void runPit_whenAllDescartesMutatorsAreSpecified() throws Exception {
         Utils.LOGGER.info("Starting Gradle Automatic Builder runPit() test when a test class is specified...");
 
-        CtClass<Object> testClass = Utils.getInputProgram().getFactory().Class().get("example.TestSuiteExample");
+        CtClass<Object> testClass = Utils.getInputConfiguration().getFactory().Class().get("example.TestSuiteExample");
 
         sut.runPit("src/test/resources/test-projects/", testClass);
         List<PitResult> pitResults = PitResultParser.parseAndDelete("src/test/resources/test-projects/" + sut.getOutputDirectoryPit());

--- a/dspot/src/test/java/eu/stamp_project/automaticbuilder/MavenAutomaticBuilderTest.java
+++ b/dspot/src/test/java/eu/stamp_project/automaticbuilder/MavenAutomaticBuilderTest.java
@@ -63,8 +63,8 @@ public class MavenAutomaticBuilderTest {
 
         Utils.init("src/test/resources/test-projects/test-projects.properties");
 
-        Utils.getBuilder().runPit(Utils.getInputProgram().getProgramDir());
-        final List<PitResult> pitResults = PitResultParser.parseAndDelete(Utils.getInputProgram().getProgramDir() + Utils.getBuilder().getOutputDirectoryPit());
+        Utils.getBuilder().runPit(Utils.getInputConfiguration().getAbsolutePathToProjectRoot());
+        final List<PitResult> pitResults = PitResultParser.parseAndDelete(Utils.getInputConfiguration().getAbsolutePathToProjectRoot() + Utils.getBuilder().getOutputDirectoryPit());
 
         assertEquals(28, pitResults.size());
         assertEquals(9, pitResults.stream().filter(pitResult -> pitResult.getStateOfMutant() == PitResult.State.SURVIVED).count());
@@ -77,14 +77,14 @@ public class MavenAutomaticBuilderTest {
         Utils.init("src/test/resources/mockito/mockito.properties");
 
         try {
-            Utils.getBuilder().runPit(Utils.getInputProgram().getProgramDir());
+            Utils.getBuilder().runPit(Utils.getInputConfiguration().getAbsolutePathToProjectRoot());
             fail("Should have thrown a RuntimeException");
         } catch (RuntimeException e) {
             //success
         }
 
         try {
-            Utils.getBuilder().runPit(Utils.getInputProgram().getProgramDir(),
+            Utils.getBuilder().runPit(Utils.getInputConfiguration().getAbsolutePathToProjectRoot(),
                     Utils.findClass("info.sanaulla.dal.BookDALTest"));
             fail("Should have thrown a RuntimeException");
         } catch (RuntimeException e) {
@@ -96,8 +96,8 @@ public class MavenAutomaticBuilderTest {
     public void testSpecificClass() throws Exception {
         Utils.init("src/test/resources/test-projects/test-projects.properties");
 
-        Utils.getBuilder().runPit(Utils.getInputProgram().getProgramDir(), Utils.findClass("example.TestSuiteExample2"));
-        final List<PitResult> pitResults = PitResultParser.parseAndDelete(Utils.getInputProgram().getProgramDir() + Utils.getBuilder().getOutputDirectoryPit());
+        Utils.getBuilder().runPit(Utils.getInputConfiguration().getAbsolutePathToProjectRoot(), Utils.findClass("example.TestSuiteExample2"));
+        final List<PitResult> pitResults = PitResultParser.parseAndDelete(Utils.getInputConfiguration().getAbsolutePathToProjectRoot() + Utils.getBuilder().getOutputDirectoryPit());
 
         assertNotNull(pitResults);
         assertEquals(28, pitResults.size());
@@ -109,8 +109,8 @@ public class MavenAutomaticBuilderTest {
     public void testMultipleClasses() throws Exception {
         Utils.init("src/test/resources/test-projects/test-projects.properties");
 
-        Utils.getBuilder().runPit(Utils.getInputProgram().getProgramDir(), Utils.findClass("example.TestSuiteExample2"), Utils.findClass("example.TestSuiteExample"));
-        final List<PitResult> pitResults = PitResultParser.parseAndDelete(Utils.getInputProgram().getProgramDir() + Utils.getBuilder().getOutputDirectoryPit());
+        Utils.getBuilder().runPit(Utils.getInputConfiguration().getAbsolutePathToProjectRoot(), Utils.findClass("example.TestSuiteExample2"), Utils.findClass("example.TestSuiteExample"));
+        final List<PitResult> pitResults = PitResultParser.parseAndDelete(Utils.getInputConfiguration().getAbsolutePathToProjectRoot() + Utils.getBuilder().getOutputDirectoryPit());
 
         assertNotNull(pitResults);
         assertEquals(28, pitResults.size());
@@ -126,10 +126,10 @@ public class MavenAutomaticBuilderTest {
 
         FileUtils.deleteDirectory(new File("src/test/resources/sample/target/pit-reports"));
 
-        Utils.getBuilder().runPit(Utils.getInputProgram().getProgramDir(),
+        Utils.getBuilder().runPit(Utils.getInputConfiguration().getAbsolutePathToProjectRoot(),
                 Utils.findClass("fr.inria.inheritance.Inherited"));
 
-        final List<PitResult> pitResults = PitResultParser.parseAndDelete(Utils.getInputProgram().getProgramDir() + Utils.getBuilder().getOutputDirectoryPit());
+        final List<PitResult> pitResults = PitResultParser.parseAndDelete(Utils.getInputConfiguration().getAbsolutePathToProjectRoot() + Utils.getBuilder().getOutputDirectoryPit());
 
         assertEquals(31, pitResults.size());
     }
@@ -139,8 +139,8 @@ public class MavenAutomaticBuilderTest {
 
         Utils.init("src/test/resources/project-with-resources/project-with-resources.properties");
 
-        Utils.getBuilder().runPit(Utils.getInputProgram().getProgramDir());
-        final List<PitResult> pitResults = PitResultParser.parseAndDelete(Utils.getInputProgram().getProgramDir() + Utils.getBuilder().getOutputDirectoryPit());
+        Utils.getBuilder().runPit(Utils.getInputConfiguration().getAbsolutePathToProjectRoot());
+        final List<PitResult> pitResults = PitResultParser.parseAndDelete(Utils.getInputConfiguration().getAbsolutePathToProjectRoot() + Utils.getBuilder().getOutputDirectoryPit());
 
         assertNotNull(pitResults);
         assertEquals(88, pitResults.size());
@@ -155,7 +155,7 @@ public class MavenAutomaticBuilderTest {
         final InputConfiguration inputConfiguration = Utils.getInputConfiguration();
         inputConfiguration.getProperties().setProperty("filter", "*");
         try {
-            Utils.getBuilder().runPit(Utils.getInputProgram().getProgramDir(), Utils.findClass("example.TestSuiteExample2"), Utils.findClass("example.TestSuiteExample"));
+            Utils.getBuilder().runPit(Utils.getInputConfiguration().getAbsolutePathToProjectRoot(), Utils.findClass("example.TestSuiteExample2"), Utils.findClass("example.TestSuiteExample"));
             fail();
         } catch (Exception e) {
 

--- a/dspot/src/test/java/eu/stamp_project/clover/CloverExecutorTest.java
+++ b/dspot/src/test/java/eu/stamp_project/clover/CloverExecutorTest.java
@@ -39,7 +39,7 @@ public class CloverExecutorTest extends AbstractTest {
          */
 
         final Map<String, Map<String, List<Integer>>> lineCoveragePerTestMethod =
-                CloverExecutor.executeAll(Utils.getInputConfiguration(), Utils.getInputProgram().getProgramDir() + "/src/");
+                CloverExecutor.executeAll(Utils.getInputConfiguration(), Utils.getInputConfiguration().getAbsolutePathToProjectRoot() + "/src/");
         final Map<String, List<Integer>> test4 = lineCoveragePerTestMethod.get("test4");
         assertTrue(test4.containsKey("example.Example"));
         assertEquals(1, test4.keySet().size());
@@ -60,7 +60,7 @@ public class CloverExecutorTest extends AbstractTest {
          */
 
         final Map<String, Map<String, List<Integer>>> lineCoveragePerTestMethod =
-                CloverExecutor.execute(Utils.getInputConfiguration(), Utils.getInputProgram().getProgramDir() + "/src/", "example.TestSuiteExample");
+                CloverExecutor.execute(Utils.getInputConfiguration(), Utils.getInputConfiguration().getAbsolutePathToProjectRoot() + "/src/", "example.TestSuiteExample");
         final Map<String, List<Integer>> test4 = lineCoveragePerTestMethod.get("test4");
         assertTrue(test4.containsKey("example.Example"));
         assertEquals(1, test4.keySet().size());

--- a/dspot/src/test/java/eu/stamp_project/dspot/DSpotAndResourcesTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/DSpotAndResourcesTest.java
@@ -4,6 +4,7 @@ import eu.stamp_project.testrunner.EntryPoint;
 import eu.stamp_project.testrunner.runner.test.TestListener;
 import eu.stamp_project.AbstractTest;
 import eu.stamp_project.Utils;
+import eu.stamp_project.utils.sosiefier.InputConfiguration;
 import eu.stamp_project.utils.sosiefier.InputProgram;
 import org.junit.Test;
 import spoon.reflect.declaration.CtClass;
@@ -29,9 +30,10 @@ public class DSpotAndResourcesTest extends AbstractTest {
 		 */
 		final CtClass<?> classUsingResources = Utils.findClass("fr.inria.testresources.TestResources");
 		final InputProgram program = Utils.getInputProgram();
-		final String classpath = program.getProgramDir() + program.getClassesDir() + PATH_SEPARATOR +
-				program.getProgramDir() + program.getTestClassesDir() + PATH_SEPARATOR +
-				Utils.getBuilder().buildClasspath(program.getProgramDir());
+		final InputConfiguration configuration = Utils.getInputConfiguration();
+		final String classpath = configuration.getAbsolutePathToProjectRoot() + program.getClassesDir() + PATH_SEPARATOR +
+				configuration.getAbsolutePathToProjectRoot() + program.getTestClassesDir() + PATH_SEPARATOR +
+				Utils.getBuilder().buildClasspath(configuration.getAbsolutePathToProjectRoot());
 
 		final TestListener result = EntryPoint.runTests(
 				classpath,

--- a/dspot/src/test/java/eu/stamp_project/dspot/DSpotMockedTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/DSpotMockedTest.java
@@ -45,7 +45,7 @@ public class DSpotMockedTest extends AbstractTest {
 		} catch (Exception ignored) {
 
 		}
-		assertEquals(6, dspot.getInputProgram().getFactory().Class().get("info.sanaulla.dal.BookDALTest").getMethods().size());
+		assertEquals(6, dspot.getInputConfiguration().getFactory().Class().get("info.sanaulla.dal.BookDALTest").getMethods().size());
 
 		EntryPoint.verbose = true;
 

--- a/dspot/src/test/java/eu/stamp_project/dspot/DSpotSelectionTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/DSpotSelectionTest.java
@@ -95,8 +95,8 @@ public class DSpotSelectionTest {
          */
 
         final List<CtType> testClasses = Arrays.asList(
-                dspotUnderTest.getInputProgram().getFactory().Type().get("example.TestSuiteExample"),
-                dspotUnderTest.getInputProgram().getFactory().Type().get("example.TestSuiteExample2")
+                dspotUnderTest.getInputConfiguration().getFactory().Type().get("example.TestSuiteExample"),
+                dspotUnderTest.getInputConfiguration().getFactory().Type().get("example.TestSuiteExample2")
         );
         dspotUnderTest.amplifyAllTests(testClasses);
         assertEquals(2, typesToBeAmplified.size());
@@ -129,7 +129,7 @@ public class DSpotSelectionTest {
             Can match specific test method in a test class
          */
 
-        final CtType<?> testClass = dspotUnderTest.getInputProgram().getFactory().Type().get("example.TestSuiteExample");
+        final CtType<?> testClass = dspotUnderTest.getInputConfiguration().getFactory().Type().get("example.TestSuiteExample");
 
         dspotUnderTest.amplifyTest(
                 testClass,

--- a/dspot/src/test/java/eu/stamp_project/dspot/amplifier/ReplacementAmplifierTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/amplifier/ReplacementAmplifierTest.java
@@ -1,9 +1,8 @@
 package eu.stamp_project.dspot.amplifier;
 
-import eu.stamp_project.Utils;
 import eu.stamp_project.AbstractTest;
+import eu.stamp_project.Utils;
 import eu.stamp_project.utils.AmplificationHelper;
-import eu.stamp_project.utils.sosiefier.InputProgram;
 import org.junit.Test;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
@@ -23,9 +22,7 @@ public class ReplacementAmplifierTest extends AbstractTest {
 
 
         final String packageName = "fr.inria.statementadd";
-        InputProgram inputProgram = Utils.getInputProgram();
-        final Factory factory = inputProgram.getFactory();
-        inputProgram.setFactory(factory);
+        final Factory factory = Utils.getFactory();
         AmplificationHelper.setSeedRandom(32L);
         ReplacementAmplifier amplifier = new ReplacementAmplifier();
         amplifier.reset(factory.Class().get(packageName + ".ClassTarget"));
@@ -51,9 +48,7 @@ public class ReplacementAmplifierTest extends AbstractTest {
          */
 
         final String packageName = "fr.inria.statementadd";
-        InputProgram inputProgram = Utils.getInputProgram();
-        final Factory factory = inputProgram.getFactory();
-        inputProgram.setFactory(factory);
+        final Factory factory = Utils.getFactory();
         AmplificationHelper.setSeedRandom(32L);
         ReplacementAmplifier amplifier = new ReplacementAmplifier();
         amplifier.reset(factory.Class().get(packageName + ".ClassTarget"));

--- a/dspot/src/test/java/eu/stamp_project/dspot/amplifier/StatementAddTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/amplifier/StatementAddTest.java
@@ -3,7 +3,6 @@ package eu.stamp_project.dspot.amplifier;
 import eu.stamp_project.AbstractTest;
 import eu.stamp_project.Utils;
 import eu.stamp_project.utils.AmplificationHelper;
-import eu.stamp_project.utils.sosiefier.InputProgram;
 import org.junit.Test;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.declaration.CtClass;
@@ -33,9 +32,7 @@ public class StatementAddTest extends AbstractTest {
          */
 
         final String packageName = "fr.inria.statementadd";
-        InputProgram inputProgram = Utils.getInputProgram();
-        final Factory factory = inputProgram.getFactory();
-        inputProgram.setFactory(factory);
+        final Factory factory = Utils.getFactory();
         AmplificationHelper.setSeedRandom(32L);
         StatementAdd amplifier = new StatementAdd(packageName);
         amplifier.reset(factory.Class().get(packageName + ".ClassTarget"));
@@ -68,9 +65,7 @@ public class StatementAddTest extends AbstractTest {
          */
 
         final String packageName = "fr.inria.statementadd";
-        InputProgram inputProgram = Utils.getInputProgram();
-        final Factory factory = inputProgram.getFactory();
-        inputProgram.setFactory(factory);
+        final Factory factory = Utils.getFactory();
         AmplificationHelper.setSeedRandom(32L);
         StatementAdd amplifier = new StatementAdd(packageName);
         amplifier.reset(factory.Class().get(packageName + ".ClassTarget"));
@@ -100,9 +95,7 @@ public class StatementAddTest extends AbstractTest {
     @Test
     public void testStatementAddOnArrayObjects() throws Exception {
         final String packageName = "fr.inria.statementaddarray";
-        InputProgram inputProgram = Utils.getInputProgram();
-        final Factory factory = inputProgram.getFactory();
-        inputProgram.setFactory(factory);
+        final Factory factory = Utils.getFactory();
         AmplificationHelper.setSeedRandom(32L);
         StatementAdd amplifier = new StatementAdd(packageName);
         amplifier.reset(factory.Class().get(packageName + ".ClassTargetAmplify"));
@@ -173,9 +166,7 @@ public class StatementAddTest extends AbstractTest {
          */
 
         final String packageName = "fr.inria.statementadd";
-        InputProgram inputProgram = Utils.getInputProgram();
-        final Factory factory = inputProgram.getFactory();
-        inputProgram.setFactory(factory);
+        final Factory factory = Utils.getFactory();
         AmplificationHelper.setSeedRandom(42L);
         StatementAdd amplifier = new StatementAdd(packageName);
         amplifier.reset(factory.Class().get(packageName + ".ClassTargetAmplify"));

--- a/dspot/src/test/java/eu/stamp_project/dspot/assertGenerator/AssertGeneratorHelperTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/assertGenerator/AssertGeneratorHelperTest.java
@@ -4,7 +4,6 @@ import eu.stamp_project.AbstractTest;
 import eu.stamp_project.Utils;
 import eu.stamp_project.dspot.amplifier.StatementAdd;
 import eu.stamp_project.utils.AmplificationHelper;
-import eu.stamp_project.utils.sosiefier.InputProgram;
 import org.junit.Test;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.declaration.CtClass;
@@ -126,10 +125,7 @@ public class AssertGeneratorHelperTest extends AbstractTest {
          */
 
         final String packageName = "fr.inria.statementaddarray";
-        InputProgram inputProgram = Utils.getInputProgram();
-        final Factory factory = inputProgram.getFactory();
-        inputProgram.setFactory(factory);
-        AmplificationHelper.setSeedRandom(32L);
+        final Factory factory = Utils.getFactory();
         StatementAdd amplifier = new StatementAdd(packageName);
         amplifier.reset(factory.Class().get(packageName + ".ClassTargetAmplify"));
 

--- a/dspot/src/test/java/eu/stamp_project/dspot/selector/ExecutedMutantSelectorTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/selector/ExecutedMutantSelectorTest.java
@@ -41,8 +41,8 @@ public class ExecutedMutantSelectorTest {
         // pre computing the number of executed mutants...
         Main.verbose = true;
         AutomaticBuilderFactory.getAutomaticBuilder(Utils.getInputConfiguration())
-                .runPit(Utils.getInputProgram().getProgramDir());
-        final List<PitResult> pitResults = PitResultParser.parseAndDelete(Utils.getInputProgram().getProgramDir() + "target/pit-reports/");
+                .runPit(Utils.getInputConfiguration().getAbsolutePathToProjectRoot());
+        final List<PitResult> pitResults = PitResultParser.parseAndDelete(Utils.getInputConfiguration().getAbsolutePathToProjectRoot() + "target/pit-reports/");
 
         final ExecutedMutantSelector testSelector = new ExecutedMutantSelector();
         DSpot dspot = new DSpot(Utils.getInputConfiguration(), 1, Collections.singletonList(new TestDataMutator()), testSelector);
@@ -55,19 +55,19 @@ public class ExecutedMutantSelectorTest {
         // then compile
         final String classpath = AutomaticBuilderFactory
                 .getAutomaticBuilder(Utils.getInputConfiguration())
-                .buildClasspath(Utils.getInputProgram().getProgramDir())
+                .buildClasspath(Utils.getInputConfiguration().getAbsolutePathToProjectRoot())
                 + AmplificationHelper.PATH_SEPARATOR +
-                Utils.getInputProgram().getProgramDir() + "/" + Utils.getInputProgram().getClassesDir()
+                Utils.getInputConfiguration().getAbsolutePathToProjectRoot() + "/" + Utils.getInputProgram().getClassesDir()
                 + AmplificationHelper.PATH_SEPARATOR + "target/dspot/dependencies/"
                 + AmplificationHelper.PATH_SEPARATOR +
-                Utils.getInputProgram().getProgramDir() + "/" + Utils.getInputProgram().getTestClassesDir();
+                Utils.getInputConfiguration().getAbsolutePathToProjectRoot() + "/" + Utils.getInputProgram().getTestClassesDir();
 
         DSpotCompiler.compile(DSpotCompiler.pathToTmpTestSources, classpath,
-                new File(Utils.getInputProgram().getProgramDir() + "/" + Utils.getInputProgram().getTestClassesDir()));
+                new File(Utils.getInputConfiguration().getAbsolutePathToProjectRoot() + "/" + Utils.getInputProgram().getTestClassesDir()));
 
         AutomaticBuilderFactory.getAutomaticBuilder(Utils.getInputConfiguration())
-                .runPit(Utils.getInputProgram().getProgramDir());
-        final List<PitResult> amplifiedPitResults = PitResultParser.parseAndDelete(Utils.getInputProgram().getProgramDir() + "target/pit-reports/");
+                .runPit(Utils.getInputConfiguration().getAbsolutePathToProjectRoot());
+        final List<PitResult> amplifiedPitResults = PitResultParser.parseAndDelete(Utils.getInputConfiguration().getAbsolutePathToProjectRoot() + "target/pit-reports/");
 
         assertTrue(pitResults.stream()
                 .filter(pitResult -> pitResult.getStateOfMutant() == PitResult.State.KILLED ||

--- a/dspot/src/test/java/eu/stamp_project/minimization/ChangeMinimizerTest.java
+++ b/dspot/src/test/java/eu/stamp_project/minimization/ChangeMinimizerTest.java
@@ -15,6 +15,7 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.visitor.filter.TypeFilter;
 
+import java.io.File;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
@@ -38,7 +39,6 @@ public class ChangeMinimizerTest extends AbstractTest {
         /*
             ChangeMinimizer keeps only the assertions that trigger the failure on the second version
          */
-
         final CtClass testClass = Utils.findClass("example.TestSuiteExample");
         final String configurationPath = Utils.getInputConfiguration().getProperty("configPath");
         final String pathToFolder = Utils.getInputConfiguration().getProperty("folderPath");
@@ -51,8 +51,9 @@ public class ChangeMinimizerTest extends AbstractTest {
                         inputConfiguration.getProperty("targetModule") +
                                 DSpotUtils.shouldAddSeparator.apply(pathToFolder)
                         : "");
+        inputConfiguration.setAbsolutePathToProjectRoot(new File(pathToChangedVersionOfProgram).getAbsolutePath());
         inputProgram.setProgramDir(pathToChangedVersionOfProgram);
-        Initializer.initialize(Utils.getInputConfiguration(), inputProgram);
+        Initializer.initialize(inputConfiguration, inputProgram);
         final HashMap<CtMethod<?>, Failure> failurePerAmplifiedTest = new HashMap<>();
         final CtMethod<?> test2 = Utils.findMethod(testClass, "test2");
         failurePerAmplifiedTest.put(test2,

--- a/dspot/src/test/java/eu/stamp_project/utils/compilation/DSpotCompilerTest.java
+++ b/dspot/src/test/java/eu/stamp_project/utils/compilation/DSpotCompilerTest.java
@@ -1,6 +1,7 @@
 package eu.stamp_project.utils.compilation;
 
 import eu.stamp_project.dspot.amplifier.Amplifier;
+import eu.stamp_project.utils.sosiefier.InputConfiguration;
 import eu.stamp_project.utils.sosiefier.InputProgram;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
@@ -36,11 +37,12 @@ public class DSpotCompilerTest {
         }
     }
 
+    // TODO update with configuration
     @Test
     public void testDSpotCompiler() throws Exception {
 
-        final InputProgram inputProgram = getInputProgram();
-        final DSpotCompiler compiler = DSpotCompiler.createDSpotCompiler(inputProgram, "");
+        final InputConfiguration configuration = getConfiguration();
+        final DSpotCompiler compiler = DSpotCompiler.createDSpotCompiler(configuration, "");
         final CtClass<?> aClass = getClass(compiler.getLauncher().getFactory());
         final List<CtMethod<?>> compile = TestCompiler.compileAndDiscardUncompilableMethods(compiler, aClass, "");
         assertTrue(compile.isEmpty());
@@ -103,6 +105,17 @@ public class DSpotCompilerTest {
         inputProgram.setRelativeSourceCodeDir("src/main/java/");
         inputProgram.setRelativeTestSourceCodeDir("src/test/java");
         return inputProgram;
+    }
+
+    private InputConfiguration getConfiguration() {
+        final InputConfiguration inputConfiguration = new InputConfiguration();
+        final InputProgram inputProgram = new InputProgram();
+        inputProgram.setProgramDir("target/dspot/trash/");
+        inputProgram.setRelativeSourceCodeDir("src/main/java/");
+        inputProgram.setRelativeTestSourceCodeDir("src/test/java");
+        inputConfiguration.setAbsolutePathToProjectRoot(new File("target/dspot/trash/").getAbsolutePath());
+        inputConfiguration.setInputProgram(inputProgram);
+        return inputConfiguration;
     }
 
     private CtClass<?> getClass(Factory factory) {

--- a/dspot/src/test/resources/regression/test-projects_0/test-projects.properties
+++ b/dspot/src/test/resources/regression/test-projects_0/test-projects.properties
@@ -11,4 +11,4 @@ filter=example.*
 #path to the output folder
 outputDirectory=target/trash/
 configPath=src/test/resources/regression/test-projects_0/test-projects.properties
-folderPath=src/test/resources/regression/test-projects_1
+folderPath=src/test/resources/regression/test-projects_1/


### PR DESCRIPTION
This Pull request aims at removing totally the InputProgram object because it is redundant, tedious and useless to use both InputConfiguration and InputProgram.

I tried to do it in one shot, but it is very complex. I'm going to do this step by step, hoping that others PR does not break it.