### PR TITLE
Open input configuration

### DIFF
--- a/dspot-maven/src/main/java/eu/stamp_project/DSpotMojo.java
+++ b/dspot-maven/src/main/java/eu/stamp_project/DSpotMojo.java
@@ -14,7 +14,10 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.List;
+import java.util.Properties;
 
 @Mojo(name = "amplify-unit-tests", defaultPhase = LifecyclePhase.VERIFY, requiresDependencyResolution = ResolutionScope.TEST)
 public class DSpotMojo extends AbstractMojo {
@@ -22,9 +25,9 @@ public class DSpotMojo extends AbstractMojo {
     private static final Logger LOGGER = LoggerFactory.getLogger(DSpotMojo.class);
 
     /**
-     *	[mandatory] specify the path to the configuration file (format Java properties) of the target project (e.g. ./foo.properties).
+     *	[optional] specify the path to the configuration file (format Java properties) of the target project (e.g. ./foo.properties).
      */
-    @Parameter(property = "path-to-properties")
+    @Parameter(property = "path-to-properties", defaultValue = "")
     private String pathToProperties;
 
     /**
@@ -173,9 +176,22 @@ public class DSpotMojo extends AbstractMojo {
         if (help) {
             JSAPOptions.showUsage();
         }
+
+        Properties properties = new Properties();
+        if (!this.pathToProperties.isEmpty()) {
+            try {
+                properties.load(new FileInputStream(this.pathToProperties));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        // TODO here, set the value readable from the pom, e.g. the base dir, source folder, test source folder, bin folder, test bin folder... etc
+        //properties.setProperty(ConstantsProperties.PROJECT_ROOT_PATH.getName(), "${project.basedir}");
+
         try {
             Main.run(
-                    InputConfiguration.initialize(this.pathToProperties)
+                    InputConfiguration.initialize(properties)
                             .setAmplifiers(AmplifierEnum.buildAmplifiersFromString(this.amplifiers.toArray(new String[this.amplifiers.size()])))
                             .setNbIteration(this.iteration)
                             .setTestClasses(this.test)

--- a/dspot/src/main/java/eu/stamp_project/program/InputConfiguration.java
+++ b/dspot/src/main/java/eu/stamp_project/program/InputConfiguration.java
@@ -67,11 +67,37 @@ public class InputConfiguration {
      *
      */
     public static InputConfiguration initialize(String pathToPropertiesFile) {
+        InputConfiguration.initialize(loadProperties(pathToPropertiesFile));
+        InputConfiguration.instance.configPath = pathToPropertiesFile;
+        return InputConfiguration.instance;
+    }
+
+    /**
+     * This method initialize the instance of the Singleton {@link InputConfiguration}.
+     * You can retrieve this instance using {@link InputConfiguration#get()}
+     * Build an InputConfiguration from a properties file, given as path.
+     * This method will call the default constructor {@link InputConfiguration#InputConfiguration(String, String, String, String, String, String)}
+     * Then, uses the properties to initialize other values.
+     * The given properties should have least values for :
+     * <ul>
+     *     <li>{@link ConstantsProperties#PROJECT_ROOT_PATH}</li>
+     *     <li>{@link ConstantsProperties#SRC_CODE}</li>
+     *     <li>{@link ConstantsProperties#TEST_SRC_CODE}</li>
+     *     <li>{@link ConstantsProperties#SRC_CLASSES}</li>
+     *     <li>{@link ConstantsProperties#TEST_CLASSES}</li>
+     *     <li>{@link ConstantsProperties#MODULE}, in case of multi module project</li>
+     * </ul>
+     *
+     * @param properties the properties. See {@link ConstantsProperties}
+     * @return the new instance of the InputConfiguration
+     *
+     */
+    public static InputConfiguration initialize(Properties properties) {
         if (InputConfiguration.instance != null) {
             LOGGER.warn("Erasing old instance of InputConfiguration");
         }
-        InputConfiguration.instance = new InputConfiguration(loadProperties(pathToPropertiesFile));
-        InputConfiguration.instance.configPath = pathToPropertiesFile;
+        InputConfiguration.instance = new InputConfiguration(properties);
+        InputConfiguration.instance.configPath = "";
         return InputConfiguration.instance;
     }
 

--- a/dspot/src/main/java/eu/stamp_project/program/InputConfiguration.java
+++ b/dspot/src/main/java/eu/stamp_project/program/InputConfiguration.java
@@ -440,12 +440,15 @@ public class InputConfiguration {
         return this.outputDirectory;
     }
 
+    @Deprecated
     private String configPath;
 
+    @Deprecated
     public String getConfigPath() {
         return configPath;
     }
 
+    @Deprecated
     public InputConfiguration setConfigPath(String configPath) {
         this.configPath = configPath;
         return this;


### PR DESCRIPTION
Hi,

This pull request allows building the instance of `InputConfiguration` from a `java.util.Properties` object.

I updated the `DSpotMojo` consequently: the path to the properties file is no longer mandatory, but still usable to set others property.

It remains to retrieve information from the `pom.xml`, like the base dir and folders of sources, binaries, and resources for instance. And test the `DSpotMojo` using different ways to launch it: command line, unit test etc...

@nicolabertazzo @spookyvale, could you please review the current changes and tell me if everything is good or what is missing? Thank you.