### PR TITLE
feat: Remove try catch fail before assertion FIX #533

### DIFF
--- a/dspot/src/main/java/eu/stamp_project/dspot/assertgenerator/AssertionRemover.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/assertgenerator/AssertionRemover.java
@@ -2,16 +2,7 @@ package eu.stamp_project.dspot.assertgenerator;
 
 import eu.stamp_project.utils.AmplificationHelper;
 import eu.stamp_project.utils.CloneHelper;
-import spoon.reflect.code.CtBlock;
-import spoon.reflect.code.CtExpression;
-import spoon.reflect.code.CtFieldRead;
-import spoon.reflect.code.CtInvocation;
-import spoon.reflect.code.CtLiteral;
-import spoon.reflect.code.CtLocalVariable;
-import spoon.reflect.code.CtStatement;
-import spoon.reflect.code.CtStatementList;
-import spoon.reflect.code.CtUnaryOperator;
-import spoon.reflect.code.CtVariableRead;
+import spoon.reflect.code.*;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
@@ -56,6 +47,12 @@ public class AssertionRemover {
                         .flatMap(invocation -> this.removeAssertion(invocation).stream())
                         .collect(Collectors.toList())
         );
+
+        testWithoutAssertion.getElements(new TypeFilter<>(CtTry.class))
+                .forEach(ctTry -> ctTry.insertBefore((CtStatement) ctTry.getBody().clone()));
+        testWithoutAssertion.getElements(new TypeFilter<>(CtTry.class))
+                .forEach(testWithoutAssertion.getBody()::removeStatement);
+
         return testWithoutAssertion;
     }
 

--- a/dspot/src/test/java/eu/stamp_project/dspot/assertgenerator/AssertionRemoverTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/assertgenerator/AssertionRemoverTest.java
@@ -9,8 +9,10 @@ import org.junit.Test;
 import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.code.CtTry;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.visitor.filter.AllTypeMembersFunction;
 import spoon.reflect.visitor.filter.TypeFilter;
 
 import static org.junit.Assert.assertEquals;
@@ -63,15 +65,23 @@ public class AssertionRemoverTest extends AbstractTest {
 
     @Test
     public void testOnCatchVariable() throws Exception {
+
+        /*
+            We remove try/catch block and Assert.fail() statement if any.
+         */
+
         final CtClass<?> testClass = Utils.findClass("fr.inria.sample.TestClassWithAssert");
-        final CtMethod<?> testWithCatchVariable = Utils.findMethod(testClass, "testWithCatchVariable");
+        final CtMethod<?> testWithCatchVariable = Utils.findMethod(testClass, "test3_exceptionCatch");
         final AssertionRemover assertionRemover = new AssertionRemover();
         final CtMethod<?> ctMethod = assertionRemover.removeAssertion(testWithCatchVariable);
-        assertTrue(
-                ctMethod.getElements(new TypeFilter<>(CtCatch.class))
-                        .get(0)
-                        .getBody()
-                        .getStatements().isEmpty());
+        assertTrue(ctMethod.getElements(new TypeFilter<>(CtCatch.class)).isEmpty());
+        assertTrue(ctMethod.getElements(new TypeFilter<>(CtTry.class)).isEmpty());
+        assertTrue(ctMethod.getElements(new TypeFilter<CtInvocation>(CtInvocation.class) {
+            @Override
+            public boolean matches(CtInvocation element) {
+                return element.getExecutable().getSimpleName().equals("fail");
+            }
+        }).isEmpty());
     }
 
     @Test

--- a/dspot/src/test/resources/sample/src/test/java/fr/inria/sample/TestClassWithAssert.java
+++ b/dspot/src/test/resources/sample/src/test/java/fr/inria/sample/TestClassWithAssert.java
@@ -1,5 +1,6 @@
 package fr.inria.sample;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/dspot/src/test/resources/sample/src/test/java/fr/inria/sample/TestClassWithAssert.java
+++ b/dspot/src/test/resources/sample/src/test/java/fr/inria/sample/TestClassWithAssert.java
@@ -63,6 +63,8 @@ public class TestClassWithAssert extends TestClassWithAssertOld {
             cl.throwException();
             junit.framework.TestCase.fail("test3 should have thrown Exception");
         } catch (java.lang.Exception eee) {
+        } finally {
+            //
         }
     }
 


### PR DESCRIPTION
With this, we have:
```java
    @Test
    public void test3_exceptionCatch() throws Exception {
        try {
            ClassThrowException cl = new ClassThrowException();
            cl.throwException();
            junit.framework.TestCase.fail("test3 should have thrown Exception");
        } catch (java.lang.Exception eee) {
        }
    }
```
and obtain:
```java
    @Test
    public void test3_exceptionCatch() throws Exception {
        ClassThrowException cl = new ClassThrowException();
        cl.throwException();
    }
```

I think it is good because after this, **DSpot** will executes it and observe that the test fails (because of the `cl.throwException();`) and then wrap it with a standard try/catch block and fail statement. In the processus of Amplification, I think this can lead to a better exploration because in one hand if an I-Ampl lead to set the program into a "correct" state, we will explore this branch, while before we don't. In the other hand, if the program stay into an "incorrect" state, **DSpot** will anyway re-wrap it with a try/catch block and a fail statement.