### PR TITLE
fix: launch checkstyle in a dedicated node of travis and skip it when…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - SCRIPT=travis-coverage.sh
   - SCRIPT=travis-jar.sh
   - SCRIPT=travis-dspot-maven.sh
+  - SCRIPT=travis-checkstyle.sh
 
 cache:
   directories:
@@ -36,11 +37,3 @@ after_success:
 branch:
   only:
     - master
-    
-notifications:
-  webhooks:
-    urls:
-      - "https://scalar.vector.im/api/neb/services/hooks/dHJhdmlzLWNpLyU0MGJkYW5nbG90JTNBbWF0cml4Lm9yZy8lMjF2bkN5V2FHSmJ4RVNBa3p5cWglM0FtYXRyaXgub3Jn"
-    on_success: change  # always|never|change
-    on_failure: always
-    on_start: never

--- a/.travis/travis-checkstyle.sh
+++ b/.travis/travis-checkstyle.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+mvn checkstyle:checkstyle

--- a/.travis/travis-deploy.sh
+++ b/.travis/travis-deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
-    cp .travis/travis-settings.xml $HOME/.m2/settings.xml && mvn deploy -DskipTests
+    cp .travis/travis-settings.xml $HOME/.m2/settings.xml && mvn deploy -DskipTests -Dcheckstyle.skip
 else
     echo "Nothing to deploy when on PR or other branch"
 fi

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/CloverCoverageSelector.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/CloverCoverageSelector.java
@@ -190,14 +190,12 @@ public class CloverCoverageSelector extends TakeAllSelector {
     }
 
     private final static String PATH_TO_COPIED_FILES = "target/dspot/copy/";
-    
 
 	private String getPathToCopiedFiles() {
-		return DSpotUtils.shouldAddSeparator.apply(this.configuration.getAbsolutePathToProjectRoot())
-				+ PATH_TO_COPIED_FILES;
+		return this.configuration.getAbsolutePathToProjectRoot() + PATH_TO_COPIED_FILES;
 	}
-	
-    private void initDirectory() {
+
+	private void initDirectory() {
         // in order to run clover easily, we have to put all the sources and
         // test classes in the same folder.
         // also, we will print amplified test in the same folder


### PR DESCRIPTION
… deploy FIX #548 

@spookyvale I create dedicated travis jobs for the checkstyle and changes will fail if the checkstyle is incorrect (which is was not the case before).