### PR TITLE
doc: update the documentation. by default, DSpot does not use any amp…

### DIFF
--- a/dspot/src/main/java/eu/stamp_project/utils/options/JSAPOptions.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/options/JSAPOptions.java
@@ -157,7 +157,7 @@ public class JSAPOptions {
         amplifiers.setStringParser(JSAP.STRING_PARSER);
         amplifiers.setUsageName("Amplifier");
         amplifiers.setDefault("None");
-        amplifiers.setHelp("[optional] specify the list of amplifiers to use. Default with all available amplifiers. " + JSAPOptions.helpForEnums(AmplifierEnum.class));
+        amplifiers.setHelp("[optional] specify the list of amplifiers to use. By default, DSpot does not use any amplifiers (None) and applies only assertion amplification." + JSAPOptions.helpForEnums(AmplifierEnum.class));
 
         FlaggedOption iteration = new FlaggedOption("iteration");
         iteration.setDefault("3");


### PR DESCRIPTION
…lifiers and applies only assertion amplification