### PR TITLE
Optimization: in DSpotUtils.printAndCompileToCheck(): extract invocat…

### DIFF
--- a/dspot/src/main/java/eu/stamp_project/utils/DSpotUtils.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/DSpotUtils.java
@@ -10,6 +10,7 @@ import spoon.compiler.Environment;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
@@ -23,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -81,15 +83,16 @@ public class DSpotUtils {
                 + ".java";
         final CtType<?> existingAmplifiedTestClass;
         if (new File(pathname).exists()) {
-            existingAmplifiedTestClass = getExistingClass(type, pathname);
+            existingAmplifiedTestClass = getExistingClass(type, pathname);//FIXME: analyse for optimisation (16% total execution time)
+            Set<CtMethod<?>> methods = type.getMethods();
             existingAmplifiedTestClass.getMethods()
                     .stream()
-                    .filter(testCase -> !type.getMethods().contains(testCase))
+                    .filter(testCase -> !methods.contains(testCase))//Optimization: extracting type.getMethods invocation.
                     .forEach(type::addMethod);
         }
         printCtTypeToGivenDirectory(type, directory, true);
         // compile
-        final boolean compile = DSpotCompiler.compile(InputConfiguration.get(),
+        final boolean compile = DSpotCompiler.compile(InputConfiguration.get(), //FIXME: analyse for optimisation (36% total execution time)
                 pathname,
                 InputConfiguration.get().getDependencies(),
                 new File(InputConfiguration.get().getOutputDirectory() + "/binaries/")
@@ -103,7 +106,7 @@ public class DSpotUtils {
             LOGGER.warn("Could not compile {} with imports.", type.getQualifiedName());
             LOGGER.warn("DSpot outputs it using full qualified names.");
             LOGGER.warn("These problems can come from the fact your project use generated codes, such as Lombok annotations.");
-            printCtTypeToGivenDirectory(type, directory, false);
+            printCtTypeToGivenDirectory(type, directory, false); //FIXME: analyse for optimisation (13% total execution time)
         }
     }
 


### PR DESCRIPTION
…ion type.getMethods() out of stream filter loop, since it is an invariant

According with profile report, CtClass.getMethods() invocation in DSpotUtils.printAndCompileToCheck() took 25% of total DSpot execution time, when applied to Dhell with following configuration:
`-i 1 --test all -a MethodAdd:AllLiteralAmplifiersMethodGeneratorAmplifier -s JacocoCoverageSelector`
This is caused because the method is invoked within the filter predicate of the stream of methods from the existing amplified test. But this method is invariant, returning always the same collection.
With this refactoring I got 30% reduction of total execution time, and same results, removing CtClass.getMethods() from the profile report.
See DSpot execution report before and after applying the refactoring:

Before:

```
======= REPORT =======
Initial instruction coverage: 294 / 1067
27.55%
Amplification results with 25 amplified tests.
Amplified instruction coverage: 296 / 1067
27.74%

2019-02-22 15:54:55,012 INFO eu.stamp_project.Main - Amplification succeed.
2019-02-22 15:54:55,013 INFO eu.stamp_project.Main - Elapsed time 1608131 ms
```
After:

```
======= REPORT =======
Initial instruction coverage: 294 / 1067
27.55%
Amplification results with 25 amplified tests.
Amplified instruction coverage: 296 / 1067
27.74%

2019-02-22 14:49:53,551 INFO eu.stamp_project.Main - Amplification succeed.
2019-02-22 14:49:53,551 INFO eu.stamp_project.Main - Elapsed time 1122073 ms
```
The new optimization profiles shows that the DSpotUtils.printAndCompileToCheck() still spends 75% of total execution time, so I will keep working on optimizing this method. I will inform you if I find new optimizations.