### PR TITLE
Optimization#3

### DIFF
--- a/dspot/pom.xml
+++ b/dspot/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>eu.stamp-project</groupId>
             <artifactId>test-runner</artifactId>
-            <version>2.0.6</version>
+            <version>2.0.7</version>
             <classifier>jar-with-dependencies</classifier>
         </dependency>
 

--- a/dspot/src/main/java/eu/stamp_project/dspot/Amplification.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/Amplification.java
@@ -8,6 +8,7 @@ import eu.stamp_project.dspot.selector.TestSelector;
 import eu.stamp_project.test_framework.TestFramework;
 import eu.stamp_project.testrunner.EntryPoint;
 import eu.stamp_project.utils.program.InputConfiguration;
+import eu.stamp_project.utils.AmplificationHelper;
 import eu.stamp_project.utils.compilation.DSpotCompiler;
 import eu.stamp_project.utils.compilation.TestCompiler;
 import eu.stamp_project.utils.report.Error;
@@ -137,6 +138,8 @@ public class Amplification {
         currentTestList.add(test);
         // output
         final List<CtMethod<?>> amplifiedTests = new ArrayList<>();
+        //Optimisation: Reset dictionary of cloned methods pointing to original ones
+        AmplificationHelper.resetTestBindingToOriginal();
         for (int i = 0; i < maxIteration; i++) {
             LOGGER.info("iteration {} / {}", i, maxIteration);
             final List<CtMethod<?>> selectedToBeAmplified;

--- a/dspot/src/main/java/eu/stamp_project/dspot/budget/NoBudgetizer.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/budget/NoBudgetizer.java
@@ -108,7 +108,11 @@ public class NoBudgetizer extends AbstractBugetizer {
         } else {
             tests.stream()
                     .filter(test -> !reducedTests.contains(test))
-                    .forEach(discardedTest -> AmplificationHelper.ampTestToParent.remove(discardedTest));
+                    .forEach(discardedTest -> {
+                        AmplificationHelper.ampTestToParent.remove(discardedTest);
+                        //Optimisation: removing discarded tests from dictionary of cloned methods
+                        AmplificationHelper.removeTestBindingToOriginal(discardedTest);
+                    });
         }
         return reducedTests;
     }

--- a/dspot/src/main/java/eu/stamp_project/utils/AmplificationHelper.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/AmplificationHelper.java
@@ -140,16 +140,17 @@ public class AmplificationHelper {
     public static CtMethod removeTestBindingToOriginal(CtMethod clonedTest) {
         synchronized(originalTestBindings) {
             //Remove entries pointing at this clonedTest
-            if (originalTestBindings.containsValue(clonedTest))
+            if (originalTestBindings.containsValue(clonedTest)) {
                 removeKeysForValue (originalTestBindings, clonedTest);
+            }
             return originalTestBindings.remove(clonedTest);
         }
     }
-    
+
     private static Set<CtMethod> getKeysForValue (Map<CtMethod<?>, CtMethod> map, CtMethod value) {
         return map.entrySet().stream().filter (o -> o.getValue().equals(value)).map(Map.Entry::getKey).collect(Collectors.toCollection(HashSet::new));
     }
-    
+
     private static void removeKeysForValue (Map<CtMethod<?>, CtMethod> map, CtMethod method) {
         Set<CtMethod> keys = getKeysForValue(map, method);
         keys.forEach(i->map.remove(i));
@@ -160,11 +161,11 @@ public class AmplificationHelper {
             return originalTestBindings.get(clonedTest);
         }
     }
-    
+
     public static int getTestBindingToOriginalSize() {
         return originalTestBindings.size();
     }
-    
+
     public static void resetTestBindingToOriginal() {
         synchronized(originalTestBindings) {
             originalTestBindings.clear();

--- a/dspot/src/main/java/eu/stamp_project/utils/AmplificationHelper.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/AmplificationHelper.java
@@ -65,7 +65,6 @@ public class AmplificationHelper {
     public static void reset() {
         CloneHelper.reset();
         ampTestToParent.clear();
-        originalTestBindings.clear();
         importByClass.clear();
     }
 
@@ -133,15 +132,43 @@ public class AmplificationHelper {
     }
 
     public static CtMethod addTestBindingToOriginal(CtMethod clonedTest, CtMethod originalTest) {
-        return originalTestBindings.put(clonedTest, originalTest);
+        synchronized(originalTestBindings) {
+            return originalTestBindings.put(clonedTest, originalTest);
+        }
     }
 
     public static CtMethod removeTestBindingToOriginal(CtMethod clonedTest) {
-        return originalTestBindings.remove(clonedTest);
+        synchronized(originalTestBindings) {
+            //Remove entries pointing at this clonedTest
+            if (originalTestBindings.containsValue(clonedTest))
+                removeKeysForValue (originalTestBindings, clonedTest);
+            return originalTestBindings.remove(clonedTest);
+        }
+    }
+    
+    private static Set<CtMethod> getKeysForValue (Map<CtMethod<?>, CtMethod> map, CtMethod value) {
+        return map.entrySet().stream().filter (o -> o.getValue().equals(value)).map(Map.Entry::getKey).collect(Collectors.toCollection(HashSet::new));
+    }
+    
+    private static void removeKeysForValue (Map<CtMethod<?>, CtMethod> map, CtMethod method) {
+        Set<CtMethod> keys = getKeysForValue(map, method);
+        keys.forEach(i->map.remove(i));
     }
 
     public static CtMethod getTestBindingToOriginal(CtMethod clonedTest) {
-        return originalTestBindings.get(clonedTest);
+        synchronized(originalTestBindings) {
+            return originalTestBindings.get(clonedTest);
+        }
+    }
+    
+    public static int getTestBindingToOriginalSize() {
+        return originalTestBindings.size();
+    }
+    
+    public static void resetTestBindingToOriginal() {
+        synchronized(originalTestBindings) {
+            originalTestBindings.clear();
+        }
     }
 
     @Deprecated


### PR DESCRIPTION
This PR solves some side effects of my previous optimization PR that uses a dictionary that holds references of cloned CtMethods to original test methods. As a consequence of that optimization:
- the number of methods hold in the dictionary scale up to provoke a memory heap exception
- in parallel execution paths (for some parallel streams), the dictionary got corrupted, causing the no resolution of some methods, which in turn, force TestFramework to resolve for some cloned methods (this should not happen).

This PR fixed this issues by:
- synchronizing the access to the dictionary
- removing dictionary entries for all methods discarded by DSpot after input amplification.
This PR also upgrades the dependency on test-runner to version 2.0.7.