### PR TITLE
fix: print the amplified test class with import FIX #745

### DIFF
--- a/dspot/src/main/java/eu/stamp_project/utils/DSpotUtils.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/DSpotUtils.java
@@ -94,7 +94,7 @@ public class DSpotUtils {
         // compile
         final boolean compile = DSpotCompiler.compile(InputConfiguration.get(), //FIXME: analyse for optimisation (36% total execution time)
                 pathname,
-                InputConfiguration.get().getDependencies(),
+                InputConfiguration.get().getFullClassPathWithExtraDependencies(),
                 new File(InputConfiguration.get().getOutputDirectory() + "/binaries/")
         );
         if (!compile) {


### PR DESCRIPTION
use now the complete classpath to compile the newly amplified test class