### PR TITLE
Fix: detection(filtering out) of @Ignored (JUnit4) or @Disabled (JUnit5) test suites before proceeding with amplification

### DIFF
--- a/dspot/src/main/java/eu/stamp_project/dspot/DSpot.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/DSpot.java
@@ -250,9 +250,15 @@ public class DSpot {
         final List<CtType<?>> testClassesToBeAmplifiedModel = testClassesToBeAmplified.stream()
                 .flatMap(this::findTestClasses)
                 .collect(Collectors.toList());
+        //Filtering out testClasses tagged as ignored (JUnit4) or disable (JUnit 5)
         return testClassesToBeAmplifiedModel.stream()
-                .map(ctType ->
-                        this._amplify(ctType, this.buildListOfTestMethodsToBeAmplified(ctType, testMethods))
+                .filter(ctType-> {
+                    boolean filtered = !TestFramework.isTestSuiteIgnore(ctType);
+                    LOGGER.info("Skiping test suite {} since it is annotated as ignored/disabled", ctType.getSimpleName());
+                    return filtered;
+                }
+                ).map(ctType ->
+                    this._amplify(ctType, this.buildListOfTestMethodsToBeAmplified(ctType, testMethods))
                 ).collect(Collectors.toList());
     }
 

--- a/dspot/src/main/java/eu/stamp_project/dspot/DSpot.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/DSpot.java
@@ -253,9 +253,11 @@ public class DSpot {
         //Filtering out testClasses tagged as ignored (JUnit4) or disable (JUnit 5)
         return testClassesToBeAmplifiedModel.stream()
                 .filter(ctType-> {
-                    boolean filtered = !TestFramework.isTestSuiteIgnore(ctType);
-                    LOGGER.info("Skiping test suite {} since it is annotated as ignored/disabled", ctType.getSimpleName());
-                    return filtered;
+                    boolean isIgnored = TestFramework.get().isIgnored(ctType);
+                    if (isIgnored) {
+                        LOGGER.info("Skiping test suite {} since it is annotated as ignored/disabled", ctType.getSimpleName());
+                    }
+                    return !isIgnored;
                 }
                 ).map(ctType ->
                     this._amplify(ctType, this.buildListOfTestMethodsToBeAmplified(ctType, testMethods))

--- a/dspot/src/main/java/eu/stamp_project/test_framework/TestFramework.java
+++ b/dspot/src/main/java/eu/stamp_project/test_framework/TestFramework.java
@@ -72,17 +72,13 @@ public class TestFramework implements TestFrameworkSupport {
      * @param ctType the test suite to check
      * @return true if the given test suite has been ignored/disabled
      */
-    public static boolean isTestSuiteIgnore (CtType<?> ctType) {
-        boolean result = false;
-        //JUnit4 case
-        result = ctType.getAnnotations().stream()
-            .anyMatch(annotation -> annotation.toString().equals("@org.junit.Ignore"));
-        //JUnit5 case
-        if (!result){
-            result = ctType.getAnnotations().stream()
-                .anyMatch(annotation -> annotation.toString().equals("@org.junit.jupiter.api.Disabled"));
+    public boolean isIgnored (CtElement candidate) {
+        for (TestFrameworkSupport testFrameworkSupport : this.testFrameworkSupportList) {
+            if (testFrameworkSupport.isIgnored(candidate)) {
+                return true;
+            }
         }
-        return result;
+        return false;
     }
 
     @Override

--- a/dspot/src/main/java/eu/stamp_project/test_framework/TestFramework.java
+++ b/dspot/src/main/java/eu/stamp_project/test_framework/TestFramework.java
@@ -67,6 +67,24 @@ public class TestFramework implements TestFrameworkSupport {
         return TestFramework.get().getTestFramework(ctMethod) instanceof JUnit5Support;
     }
 
+    /**
+     * This method detects whether or not the given test suite has been annotated to be ignored (JUnit4) or disabled (JUnit5)
+     * @param ctType the test suite to check
+     * @return true if the given test suite has been ignored/disabled
+     */
+    public static boolean isTestSuiteIgnore (CtType<?> ctType) {
+        boolean result = false;
+        //JUnit4 case
+        result = ctType.getAnnotations().stream()
+            .anyMatch(annotation -> annotation.toString().equals("@org.junit.Ignore"));
+        //JUnit5 case
+        if (!result){
+            result = ctType.getAnnotations().stream()
+                .anyMatch(annotation -> annotation.toString().equals("@org.junit.jupiter.api.Disabled"));
+        }
+        return result;
+    }
+
     @Override
     public boolean isAssert(CtInvocation<?> invocation) {
         for (TestFrameworkSupport testFrameworkSupport : this.testFrameworkSupportList) {

--- a/dspot/src/main/java/eu/stamp_project/test_framework/TestFrameworkSupport.java
+++ b/dspot/src/main/java/eu/stamp_project/test_framework/TestFrameworkSupport.java
@@ -92,4 +92,10 @@ public interface TestFrameworkSupport {
      */
     public void generateAfterClassToSaveObservations(CtType<?> testClass, List<CtMethod<?>> testsToRun);
 
+    /**
+     * This method detects whether or not the given element (test or suite) has been annotated to be ignored (JUnit4) or disabled (JUnit5)
+     * @param ctType the test suite to check
+     * @return true if the given test suite has been ignored/disabled
+     */
+    public boolean isIgnored(CtElement candidate);
 }

--- a/dspot/src/main/java/eu/stamp_project/test_framework/implementations/AssertJTestFramework.java
+++ b/dspot/src/main/java/eu/stamp_project/test_framework/implementations/AssertJTestFramework.java
@@ -5,6 +5,7 @@ import eu.stamp_project.test_framework.assertions.AssertEnum;
 import eu.stamp_project.testrunner.runner.Failure;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtInvocation;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 
@@ -44,5 +45,10 @@ public class AssertJTestFramework extends AbstractTestFramework {
     @Override
     public void generateAfterClassToSaveObservations(CtType<?> testClass, List<CtMethod<?>> testsToRun) {
         // TODO
+    }
+
+    @Override
+    public boolean isIgnored(CtElement candidate) {
+        return false;
     }
 }

--- a/dspot/src/main/java/eu/stamp_project/test_framework/implementations/GoogleTruthTestFramework.java
+++ b/dspot/src/main/java/eu/stamp_project/test_framework/implementations/GoogleTruthTestFramework.java
@@ -5,6 +5,7 @@ import eu.stamp_project.test_framework.assertions.AssertEnum;
 import eu.stamp_project.utils.program.InputConfiguration;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtInvocation;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtExecutableReference;
@@ -68,4 +69,8 @@ public class GoogleTruthTestFramework extends AbstractTestFrameworkDecorator {
     public static final String ASSERT_EQUALS = "isEqualTo";
     public static final String ASSERT_NOT_EQUALS = "isNotEqualTo";
 
+    @Override
+    public boolean isIgnored(CtElement candidate) {
+        return false;
+    }
 }

--- a/dspot/src/main/java/eu/stamp_project/test_framework/implementations/NoneTestFrameworkSupport.java
+++ b/dspot/src/main/java/eu/stamp_project/test_framework/implementations/NoneTestFrameworkSupport.java
@@ -58,4 +58,9 @@ public class NoneTestFrameworkSupport implements TestFrameworkSupport {
     public void generateAfterClassToSaveObservations(CtType<?> testClass, List<CtMethod<?>> testsToRun) {
 
     }
+
+    @Override
+    public boolean isIgnored(CtElement candidate) {
+        return false;
+    }
 }

--- a/dspot/src/main/java/eu/stamp_project/test_framework/implementations/junit/JUnit3Support.java
+++ b/dspot/src/main/java/eu/stamp_project/test_framework/implementations/junit/JUnit3Support.java
@@ -5,6 +5,7 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
@@ -41,10 +42,11 @@ public class JUnit3Support extends JUnitSupport {
 
     /*
         For JUnit3, a test method starts by test, otherwise we consider ignored
+        Test suites cannot be ignore at class level
      */
     @Override
-    protected boolean isIgnored(CtMethod<?> candidate) {
-        return !candidate.getSimpleName().startsWith("test");
+    public boolean isIgnored(CtElement candidate) {
+        return candidate instanceof CtMethod?!((CtMethod<?>)candidate).getSimpleName().startsWith("test"):false;
     }
 
     /*

--- a/dspot/src/main/java/eu/stamp_project/test_framework/implementations/junit/JUnitSupport.java
+++ b/dspot/src/main/java/eu/stamp_project/test_framework/implementations/junit/JUnitSupport.java
@@ -32,7 +32,7 @@ public abstract class JUnitSupport extends AbstractTestFramework {
 
     protected abstract String getFullQualifiedNameOfAnnotationAfterClass();
 
-    protected boolean isIgnored(CtMethod<?> candidate) {
+    public boolean isIgnored(CtElement candidate) {
         return this.hasAnnotation(getFullQualifiedNameOfAnnotationIgnore(), candidate);
     }
 


### PR DESCRIPTION
Experimenting DSpot in some Supersede IF test classes (suites) I faced some NPE errors caused by TestRunner problems to execute the test and obtain an nonexistent serialized TestResult.ser.
So I debugged these experiments and realized that the _MethodFilter_ in _JUnit4Runner_ was receiving in its method _shouldRun_ a wrong _Description_ for a test class with not test methods. So, inspecting my Supersede IF test suite I realized it was ignored by @Ignore annotation. Despite that, DSpot was trying to amplify the test. So, I've created this PR that filters out all JUnit4 @Ignored and JUnit5 @Disable test classes, reporting them in logs (INFO).
I will create a bug report associated to this PR.