### PR TITLE
Feat: keep intermediate reports FIX #911

### DIFF
--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/ChangeDetectorSelector.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/ChangeDetectorSelector.java
@@ -22,10 +22,7 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 
 import java.io.*;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Created by Benjamin DANGLOT
@@ -161,7 +158,7 @@ public class ChangeDetectorSelector extends AbstractTestSelector {
                 );
         final TestClassJSON testClassJSON = this.reportJson();
         this.reset();
-        return new TestSelectorElementReportImpl(output.toString(), testClassJSON);
+        return new TestSelectorElementReportImpl(output.toString(), testClassJSON, Collections.emptyList(), "");
     }
 
     private TestClassJSON reportJson() {

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/JacocoCoverageSelector.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/JacocoCoverageSelector.java
@@ -26,6 +26,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
@@ -210,7 +211,7 @@ public class JacocoCoverageSelector extends TakeAllSelector {
                             (double) coverageResults.getInstructionsTotal())))
                     .append("%")
                     .append(AmplificationHelper.LINE_SEPARATOR);
-            lastReport = new TestSelectorElementReportImpl(report.toString(), jsonReport(coverageResults));
+            lastReport = new TestSelectorElementReportImpl(report.toString(), jsonReport(coverageResults), Collections.emptyList(), "");
 
             return lastReport;
         } catch (TimeoutException e) {

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/TakeAllSelector.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/TakeAllSelector.java
@@ -8,6 +8,7 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -50,7 +51,7 @@ public class TakeAllSelector extends AbstractTestSelector {
 	public TestSelectorElementReport report() {
 		final String report = "Amplification results with " + this.selectedAmplifiedTest.size() + " new tests.";
 		reset();
-		return new TestSelectorElementReportImpl(report, null);
+		return new TestSelectorElementReportImpl(report, null, Collections.emptyList(), "");
 	}
 
 	@Override

--- a/dspot/src/main/java/eu/stamp_project/utils/pit/AbstractParser.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/pit/AbstractParser.java
@@ -14,7 +14,7 @@ abstract public class AbstractParser<T extends  AbstractPitResult> {
         this.PATH_TO_MUTATIONS_RESULT = PATH_TO_MUTATIONS_RESULT;
     }
 
-    protected File getPathOfMutationsFile(String pathToDirectoryResults) {
+    public File getPathOfMutationsFile(String pathToDirectoryResults) {
         if (!new File(pathToDirectoryResults).exists()) {
             return null;
         }

--- a/dspot/src/main/java/eu/stamp_project/utils/report/output/selector/TestSelectorElementReportImpl.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/report/output/selector/TestSelectorElementReportImpl.java
@@ -8,6 +8,7 @@ import spoon.reflect.declaration.CtType;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.List;
 
 /**
  * created by Benjamin DANGLOT
@@ -22,9 +23,18 @@ public class TestSelectorElementReportImpl implements TestSelectorElementReport 
 
     private TestClassJSON testClassJSON;
 
-    public TestSelectorElementReportImpl(String textualReport, TestClassJSON testClassJSON) {
+    private List<String> testCriterionReports;
+
+    private String extension;
+
+    public TestSelectorElementReportImpl(String textualReport,
+                                         TestClassJSON testClassJSON,
+                                         List<String> testCriterionReports,
+                                         String extension) {
         this.textualReport = textualReport;
         this.testClassJSON = testClassJSON;
+        this.testCriterionReports = testCriterionReports;
+        this.extension = extension;
     }
 
     @Override
@@ -44,7 +54,20 @@ public class TestSelectorElementReportImpl implements TestSelectorElementReport 
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        // 2 return the textual report for this test classTestClassJSON
+        // 2 output the baseline, intermediate and final test criterion reports
+        final String reportPathName = DSpotUtils.shouldAddSeparator
+                .apply(outputDirectory) + testClass.getQualifiedName().replaceAll("\\.", "_")
+                + "_test_criterion_report_";
+        testCriterionReports.forEach(testCriterionReportContent -> {
+                    try (FileWriter writer =
+                                 new FileWriter(reportPathName + testCriterionReports.indexOf(testCriterionReportContent) + this.extension, false)) {
+                        writer.write(testCriterionReportContent);
+                    } catch (Exception e) {
+                        //ignored
+                    }
+                }
+        );
+        // 3 return the textual report for this test classTestClassJSON
         return this.textualReport;
     }
 

--- a/dspot/src/main/java/eu/stamp_project/utils/report/output/selector/TestSelectorReportImpl.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/report/output/selector/TestSelectorReportImpl.java
@@ -8,8 +8,7 @@ import spoon.reflect.declaration.CtType;
 
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -21,7 +20,7 @@ public class TestSelectorReportImpl implements TestSelectorReport {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TestSelectorReport.class);
 
-    private Map<CtType<?>, TestSelectorElementReportImpl> testSelectorElementReportPerTestClass;
+    private Map<CtType<?>, TestSelectorElementReport> testSelectorElementReportPerTestClass;
 
     public TestSelectorReportImpl() {
         this.testSelectorElementReportPerTestClass = new HashMap<>();

--- a/dspot/src/test/java/eu/stamp_project/utils/pit/PitCSVParserAndResultTest.java
+++ b/dspot/src/test/java/eu/stamp_project/utils/pit/PitCSVParserAndResultTest.java
@@ -34,31 +34,4 @@ public class PitCSVParserAndResultTest {
         assertEquals(1014, pitCSVResults.stream().filter(pitResult -> pitResult.getStateOfMutant() == PitCSVResult.State.NO_COVERAGE).count(), nbErrors);
     }
 
-    @Test
-    public void testOnPitResultCSV() throws IOException {
-
-
-        /*
-                reading, output and re-read should give the save as the first read
-                In this test, we use the toString() method of PitCSVResult to transform the
-                 List<PitCSVResult> into List<String>
-                Then we create a TestSelectorElementReportImpl (we do not care of the textual report and the test class JSON)
-                Then the file read (raw) and the string built must be equals
-        */
-
-        final PitCSVResultParser parser = new PitCSVResultParser();
-        final String FILE_PATH_NAME = "src/test/resources/catalog.csv";
-        final List<PitCSVResult> parse = parser.parse(new File(FILE_PATH_NAME));
-        // transform the PitCSVResult into String using overridden toString() method
-        final String resultAsString = parse.stream().map(Object::toString).collect(Collectors.joining(AmplificationHelper.LINE_SEPARATOR));
-        try (BufferedReader buffer = new BufferedReader(new FileReader(FILE_PATH_NAME))) {
-            assertEquals(
-                    buffer.lines()
-                            .collect(
-                                    Collectors.joining(AmplificationHelper.LINE_SEPARATOR)
-                            ), resultAsString
-            );
-        }
-    }
-
 }

--- a/dspot/src/test/java/eu/stamp_project/utils/pit/PitCSVParserAndResultTest.java
+++ b/dspot/src/test/java/eu/stamp_project/utils/pit/PitCSVParserAndResultTest.java
@@ -1,9 +1,15 @@
 package eu.stamp_project.utils.pit;
 
+import eu.stamp_project.utils.AmplificationHelper;
+import eu.stamp_project.utils.report.output.selector.TestSelectorElementReportImpl;
 import org.junit.Test;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -27,4 +33,32 @@ public class PitCSVParserAndResultTest {
         assertEquals(3343, pitCSVResults.stream().filter(pitResult -> pitResult.getStateOfMutant() == PitCSVResult.State.KILLED).count(), nbErrors);
         assertEquals(1014, pitCSVResults.stream().filter(pitResult -> pitResult.getStateOfMutant() == PitCSVResult.State.NO_COVERAGE).count(), nbErrors);
     }
+
+    @Test
+    public void testOnPitResultCSV() throws IOException {
+
+
+        /*
+                reading, output and re-read should give the save as the first read
+                In this test, we use the toString() method of PitCSVResult to transform the
+                 List<PitCSVResult> into List<String>
+                Then we create a TestSelectorElementReportImpl (we do not care of the textual report and the test class JSON)
+                Then the file read (raw) and the string built must be equals
+        */
+
+        final PitCSVResultParser parser = new PitCSVResultParser();
+        final String FILE_PATH_NAME = "src/test/resources/catalog.csv";
+        final List<PitCSVResult> parse = parser.parse(new File(FILE_PATH_NAME));
+        // transform the PitCSVResult into String using overridden toString() method
+        final String resultAsString = parse.stream().map(Object::toString).collect(Collectors.joining(AmplificationHelper.LINE_SEPARATOR));
+        try (BufferedReader buffer = new BufferedReader(new FileReader(FILE_PATH_NAME))) {
+            assertEquals(
+                    buffer.lines()
+                            .collect(
+                                    Collectors.joining(AmplificationHelper.LINE_SEPARATOR)
+                            ), resultAsString
+            );
+        }
+    }
+
 }

--- a/dspot/src/test/java/eu/stamp_project/utils/pit/PitXMLParserAndResultTest.java
+++ b/dspot/src/test/java/eu/stamp_project/utils/pit/PitXMLParserAndResultTest.java
@@ -1,8 +1,15 @@
 package eu.stamp_project.utils.pit;
 
+import eu.stamp_project.utils.AmplificationHelper;
 import org.junit.Test;
+
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -11,6 +18,7 @@ import static org.junit.Assert.assertEquals;
  * on 14/11/18
  */
 public class PitXMLParserAndResultTest {
+
     @Test
     public void test() throws Exception {
         final List<? extends AbstractPitResult> pitXMLResults = (new PitXMLResultParser()).parse(new File("src/test/resources/mutations_test-projects.xml"));
@@ -23,5 +31,38 @@ public class PitXMLParserAndResultTest {
         assertEquals(9, pitXMLResults.stream().filter(pitResult -> pitResult.getStateOfMutant() == AbstractPitResult.State.SURVIVED).count(), nbErrors);
         assertEquals(15, pitXMLResults.stream().filter(pitResult -> pitResult.getStateOfMutant() == AbstractPitResult.State.KILLED).count(), nbErrors);
         assertEquals(4, pitXMLResults.stream().filter(pitResult -> pitResult.getStateOfMutant() == AbstractPitResult.State.NO_COVERAGE).count(), nbErrors);
+    }
+
+    @Test
+    public void testOnPitResultCSV() throws IOException {
+
+
+        /*
+                reading, output and re-read should give the save as the first read
+                In this test, we use the toString() method of PitCSVResult to transform the
+                 List<PitCSVResult> into List<String>
+                Then we create a TestSelectorElementReportImpl (we do not care of the textual report and the test class JSON)
+                Then the file read (raw) and the string built must be equals
+        */
+
+        final PitXMLResultParser parser = new PitXMLResultParser();
+        final String FILE_PATH_NAME = "src/test/resources/mutations_test-projects.xml";
+        final List<PitXMLResult> parse = parser.parse(new File(FILE_PATH_NAME));
+        // transform the PitCSVResult into String using overridden toString() method
+        final String resultAsString = parse.stream().map(Object::toString).collect(Collectors.joining(AmplificationHelper.LINE_SEPARATOR));
+        try (BufferedReader buffer = new BufferedReader(new FileReader(FILE_PATH_NAME))) {
+            final String header = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + AmplificationHelper.LINE_SEPARATOR +
+                    "<mutations>" + AmplificationHelper.LINE_SEPARATOR;
+            final String footer = "</mutations>";
+            assertEquals(
+                    buffer.lines()
+                            .collect(
+                                    Collectors.joining(AmplificationHelper.LINE_SEPARATOR)
+                            ),
+                    header +
+                    resultAsString + AmplificationHelper.LINE_SEPARATOR +
+                            footer
+            );
+        }
     }
 }

--- a/dspot/src/test/java/eu/stamp_project/utils/pit/PitXMLParserAndResultTest.java
+++ b/dspot/src/test/java/eu/stamp_project/utils/pit/PitXMLParserAndResultTest.java
@@ -32,37 +32,4 @@ public class PitXMLParserAndResultTest {
         assertEquals(15, pitXMLResults.stream().filter(pitResult -> pitResult.getStateOfMutant() == AbstractPitResult.State.KILLED).count(), nbErrors);
         assertEquals(4, pitXMLResults.stream().filter(pitResult -> pitResult.getStateOfMutant() == AbstractPitResult.State.NO_COVERAGE).count(), nbErrors);
     }
-
-    @Test
-    public void testOnPitResultCSV() throws IOException {
-
-
-        /*
-                reading, output and re-read should give the save as the first read
-                In this test, we use the toString() method of PitCSVResult to transform the
-                 List<PitCSVResult> into List<String>
-                Then we create a TestSelectorElementReportImpl (we do not care of the textual report and the test class JSON)
-                Then the file read (raw) and the string built must be equals
-        */
-
-        final PitXMLResultParser parser = new PitXMLResultParser();
-        final String FILE_PATH_NAME = "src/test/resources/mutations_test-projects.xml";
-        final List<PitXMLResult> parse = parser.parse(new File(FILE_PATH_NAME));
-        // transform the PitCSVResult into String using overridden toString() method
-        final String resultAsString = parse.stream().map(Object::toString).collect(Collectors.joining(AmplificationHelper.LINE_SEPARATOR));
-        try (BufferedReader buffer = new BufferedReader(new FileReader(FILE_PATH_NAME))) {
-            final String header = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + AmplificationHelper.LINE_SEPARATOR +
-                    "<mutations>" + AmplificationHelper.LINE_SEPARATOR;
-            final String footer = "</mutations>";
-            assertEquals(
-                    buffer.lines()
-                            .collect(
-                                    Collectors.joining(AmplificationHelper.LINE_SEPARATOR)
-                            ),
-                    header +
-                    resultAsString + AmplificationHelper.LINE_SEPARATOR +
-                            footer
-            );
-        }
-    }
 }


### PR DESCRIPTION
@borisbaldassari @monperrus WDYT ?

The idea is to save keep the string representation of the reports and output them in the output directory of DSpot.

You will have the baseline (before amplification), during and after amplification.

For now, I implemented it only for Descartes (PitMutantScoreSelector).

The report files are named like this: `full.qualified.name.of.test.class_test_criterion_report_<index>`, where `<index>` is the index of the reports in the list of reports, _e.g._ `0` for the baseline.