### PR TITLE
fix default maven test

### DIFF
--- a/.travis/travis-coverage.sh
+++ b/.travis/travis-coverage.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-cd dspot && mvn -Pcoveralls -DTRAVIS_JOB_ID=$TRAVIS_JOB_ID clean test jacoco:report coveralls:report
+cd dspot && mvn -Pcoveralls -DTRAVIS_JOB_ID=$TRAVIS_JOB_ID -DdoIntegrationTests=true clean test jacoco:report coveralls:report

--- a/.travis/travis-openjdk8.sh
+++ b/.travis/travis-openjdk8.sh
@@ -2,9 +2,5 @@
 
 set -e
 
-source /opt/jdk_switcher/jdk_switcher.sh
-
-jdk_switcher use openjdk8
-
 # see doIntegrationTests=true -> see https://stackoverflow.com/a/15881238
-mvn -Djava.src.version=1.8 test -DdoIntegrationTests=true -f dspot/pom.xml
+mvn -Djava.src.version=1.8 -DdoIntegrationTests=true test -f dspot/pom.xml

--- a/.travis/travis-openjdk8.sh
+++ b/.travis/travis-openjdk8.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+set -e
+
 source /opt/jdk_switcher/jdk_switcher.sh
 
-jdk_switcher use openjdk8 & mvn -Djava.src.version=1.8 test -f dspot/pom.xml
+jdk_switcher use openjdk8
+
+# see doIntegrationTests=true -> see https://stackoverflow.com/a/15881238
+mvn -Djava.src.version=1.8 test -DdoIntegrationTests=true -f dspot/pom.xml

--- a/dspot/src/test/java/eu/stamp_project/dspot/common/automaticbuilder/gradle/GradleAutomaticBuilderTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/common/automaticbuilder/gradle/GradleAutomaticBuilderTest.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Created by Daniele Gagliardi
@@ -44,6 +45,7 @@ public class GradleAutomaticBuilderTest {
 
     @Before
     public void setUp() throws Exception {
+        assumeTrue("true".equals(System.getProperty("doIntegrationTests")));
         DSpotState.verbose = true;
         cleanTestEnv();
         LOGGER.debug("Test Set-up - Reading input parameters...");

--- a/dspot/src/test/java/eu/stamp_project/dspot/common/collector/mongodb/MongodbCollectorTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/common/collector/mongodb/MongodbCollectorTest.java
@@ -3,7 +3,7 @@ package eu.stamp_project.dspot.common.collector.mongodb;
 import org.junit.Test;
 import org.junit.Before;
 import org.junit.After;
-
+import static org.junit.Assume.assumeTrue;
 import static org.junit.Assert.assertEquals;
 
 import eu.stamp_project.Main;
@@ -38,6 +38,8 @@ public class MongodbCollectorTest {
 
     @Test
     public void testInfoSubmissionToMongodbPitMutantScoreSelector() {
+        // don't run this test if mongodb is not installed locally
+        assumeTrue("true".equals(System.getProperty("doIntegrationTests")));
         Main.main(new String[]{
                 "--absolute-path-to-project-root", "src/test/resources/sample/",
                 "--test-criterion", "PitMutantScoreSelector",
@@ -70,6 +72,8 @@ public class MongodbCollectorTest {
 
     @Test
     public void testInfoSubmissionToMongodbJacocoCoverageSelector() {
+        // don't run this test if mongodb is not installed locally
+        assumeTrue("true".equals(System.getProperty("doIntegrationTests")));
         Main.main(new String[]{
                 "--absolute-path-to-project-root", "src/test/resources/project-with-resources/",
                 "--test-criterion", "JacocoCoverageSelector",
@@ -98,6 +102,8 @@ public class MongodbCollectorTest {
     @Test
     /* Should update an existing document then have tried sending an email at the end*/
     public void testRestful() {
+        // don't run this test if mongodb is not installed locally
+        assumeTrue("true".equals(System.getProperty("doIntegrationTests")));
         Document initDoc = new Document("RepoSlug", "USER/Testing")
                 .append("RepoBranch", "master")
                 .append("State", "pending")


### PR DESCRIPTION
Problem: a simple `mvn test` fails, because of complex dependencies for integration tests, see https://ci.inria.fr/sos/job/dspot/14/console

Solution: add a flag `doIntegrationTests` disabled by default