### PR TITLE
Fix nullpointer exception when reporting with TakeAllSelector

### DIFF
--- a/dspot/src/main/java/eu/stamp_project/dspot/common/report/output/selector/takeall/json/TestClassJSON.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/common/report/output/selector/takeall/json/TestClassJSON.java
@@ -1,0 +1,13 @@
+package eu.stamp_project.dspot.common.report.output.selector.takeall.json;
+
+/**
+ * Created by Carolin BRANDT
+ * c.e.brandt@tudelft.nl
+ * on 05/14/20
+ */
+public class TestClassJSON implements eu.stamp_project.dspot.common.report.output.selector.TestClassJSON {
+
+    public String toString(){
+       return "";
+    }
+}

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/TakeAllSelector.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/TakeAllSelector.java
@@ -4,6 +4,7 @@ import eu.stamp_project.dspot.common.automaticbuilder.AutomaticBuilder;
 import eu.stamp_project.dspot.common.configuration.UserInput;
 import eu.stamp_project.dspot.common.report.output.selector.TestSelectorElementReport;
 import eu.stamp_project.dspot.common.report.output.selector.TestSelectorElementReportImpl;
+import eu.stamp_project.dspot.common.report.output.selector.takeall.json.TestClassJSON;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 
@@ -51,7 +52,7 @@ public class TakeAllSelector extends AbstractTestSelector {
 	public TestSelectorElementReport report() {
 		final String report = "Amplification results with " + this.selectedAmplifiedTest.size() + " new tests.";
 		reset();
-		return new TestSelectorElementReportImpl(report, null, Collections.emptyList(), "");
+		return new TestSelectorElementReportImpl(report, new TestClassJSON(), Collections.emptyList(), "");
 	}
 
 	@Override

--- a/dspot/src/test/java/eu/stamp_project/dspot/selector/TakeAllSelectorTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/selector/TakeAllSelectorTest.java
@@ -5,6 +5,7 @@ import spoon.reflect.declaration.CtMethod;
 
 import java.util.Collections;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 /**
@@ -46,5 +47,10 @@ public class TakeAllSelectorTest extends AbstractSelectorTest {
 		);
 		assertFalse(this.testSelectorUnderTest.getAmplifiedTestCases().isEmpty());
 		this.testSelectorUnderTest.report();
+	}
+
+	@Test
+	public void testReportForCollector() {
+		assertEquals("", this.testSelectorUnderTest.report().getReportForCollector());
 	}
 }


### PR DESCRIPTION
When using the TakeAllSelector, a null pointer exception appears in the output log.

Example excerpt from the log from running `MainTest..testMainWithEmptyTestMethods()` on master:
```
[INFO] 2020-06-01 11:10:10 DSpot - elapsedTime 1310
java.lang.NullPointerException
	at eu.stamp_project.dspot.common.report.output.selector.TestSelectorElementReportImpl.getReportForCollector(TestSelectorElementReportImpl.java:42)
	at eu.stamp_project.dspot.common.configuration.AmplificationSetup.postAmplification(AmplificationSetup.java:84)
	at eu.stamp_project.dspot.DSpot.run(DSpot.java:54)
	at eu.stamp_project.Main.main(Main.java:20)
	at eu.stamp_project.MainTest.testMainWithEmptyTestMethods(MainTest.java:164)
	at ...
[ERROR] 2020-06-01 11:10:10 DSpot - Something bad happened during the report fot test-criterion.
```

I added a simple `TestClassJSON` for the TakeAllSelector, and a test case that shows that the NullPointerException is no longer appearing.