### PR TITLE
Feat: Add option to only perform input amplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ java -jar /path/to/dspot-LATEST-jar-with-dependencies.jar --absolute-path-to-pro
 
 ```
 Usage: eu.stamp_project.Main [-hvV] [--allow-path-in-assertions] [--clean] [--example] [--execute-test-parallel]
-                             [--generate-new-test-class] [--gregor-mode] [--keep-original-test-methods] [--restful]
-                             [--smtp-auth] [--target-one-test-class] [--use-maven-to-exe-test]
-                             [--use-working-directory] [--with-comment]
+                             [--generate-new-test-class] [--gregor-mode] [--keep-original-test-methods]
+                             [--only-input-amplification] [--restful] [--smtp-auth] [--target-one-test-class]
+                             [--use-maven-to-exe-test] [--use-working-directory] [--with-comment]
                              [--absolute-path-to-project-root=<absolutePathToProjectRoot>]
                              [--absolute-path-to-second-version=<absolutePathToSecondVersionProjectRoot>]
                              [--automatic-builder=<automaticBuilder>] [--cache-size=<cacheSize>]
@@ -250,6 +250,8 @@ Usage: eu.stamp_project.Main [-hvV] [--allow-path-in-assertions] [--clean] [--ex
       --nb-parallel-exe-processors=<numberParallelExecutionProcessors>
                              Specify the number of processor to use for the parallel execution.0 will make DSpot use
                                all processors available. Default value: 0
+      --only-input-amplification
+                             Only apply input amplification. Default value: false
       --output-path, --output-directory=<outputDirectory>
                              specify a path folder for the output. Default value: target/dspot/output/
       --path-pit-result=<pathPitResult>
@@ -370,6 +372,8 @@ However, **DSpot** provide different kind of `Amplifier`:
    * `ArrayAmplifier`: replaces value of arrays 
    * `ReturnValueAmplifier`: creates objects based on the returned value by existing method call
    * `None`: do nothing
+
+If you only want to use these amplifiers and not generate assertions, use `--only-input-amplification`.
 
 #### Test Selectors (-s | --test-selector | --test-criterion)
 

--- a/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/DSpotState.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/DSpotState.java
@@ -34,6 +34,7 @@ public class DSpotState {
     private List<String> testMethodsToBeAmplifiedNames;
     private TestSelector testSelector;
     private InputAmplDistributor inputAmplDistributor;
+    private boolean onlyInputAmplification;
     private Output output;
     private Collector collector;
     private boolean collectData;
@@ -53,6 +54,7 @@ public class DSpotState {
         userInput = new UserInput();
         testMethodsToBeAmplifiedNames = Collections.emptyList();
         collectData = false;
+        onlyInputAmplification = false;
     }
 
     /**
@@ -62,6 +64,14 @@ public class DSpotState {
      */
     public void clearData(){
         this.assertionGenerator = new AssertionGenerator(delta, this.compiler, this.testCompiler);
+    }
+
+    public boolean isOnlyInputAmplification() {
+        return onlyInputAmplification;
+    }
+
+    public void setOnlyInputAmplification(boolean onlyInputAmplification) {
+        this.onlyInputAmplification = onlyInputAmplification;
     }
 
     public int getNbIteration() {

--- a/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/InitializeDSpot.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/InitializeDSpot.java
@@ -38,6 +38,7 @@ public class InitializeDSpot {
     public void init(UserInput userInput) {
         this.DSpotState = new DSpotState();
         DSpotState.setUserInput(userInput);
+        DSpotState.setOnlyInputAmplification(userInput.isOnlyInputAmplification());
         DSpotState.verbose = userInput.isVerbose();
         DSpotState.setStartTime(System.currentTimeMillis());
         DSpotState.setTestFinder(new TestFinder(

--- a/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/UserInput.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/UserInput.java
@@ -147,6 +147,14 @@ public class UserInput {
     )
     private String outputDirectory = "target/dspot/output/";
 
+    @CommandLine.Option(
+            names = "--only-input-amplification",
+            defaultValue = "false",
+            description = "Only apply input amplification."+
+                    " Default value: ${DEFAULT-VALUE}"
+    )
+    private boolean onlyInputAmplification;
+
     /*
         advanced amplification process configuration
      */
@@ -580,6 +588,15 @@ public class UserInput {
                     " Default value: ${DEFAULT-VALUE}"
     )
     private String smtpTls;
+
+    public boolean isOnlyInputAmplification() {
+        return onlyInputAmplification;
+    }
+
+    public UserInput setOnlyInputAmplification(boolean onlyInputAmplification) {
+        this.onlyInputAmplification = onlyInputAmplification;
+        return this;
+    }
 
     public String getAbsolutePathToTopProjectRoot() {
         return absolutePathToProjectRoot;

--- a/dspot/src/test/java/eu/stamp_project/MainTest.java
+++ b/dspot/src/test/java/eu/stamp_project/MainTest.java
@@ -204,6 +204,19 @@ public class MainTest {
     }
 
     @Test
+    public void testOnlyInputAmplification() throws Exception {
+        Main.main(new String[]{
+                "--verbose",
+                "--absolute-path-to-project-root", new File("src/test/resources/test-projects/").getAbsolutePath() + "/",
+                "--amplifiers", "FastLiteralAmplifier",
+                "--test-criterion", "JacocoCoverageSelector",
+                "--test", "example.TestSuiteExample2",
+                "--only-input-amplification",
+        });
+        assertTrue(new File("target/dspot/output/example/TestSuiteExample2.java").exists());
+    }
+
+    @Test
     public void testExample() throws Exception {
 
         /*


### PR DESCRIPTION
Adds an option to skip assertion generation and only perform input amplification on the test cases.
