### PR TITLE
fix travis build - prettifier job

### DIFF
--- a/.travis/travis-prettifier.sh
+++ b/.travis/travis-prettifier.sh
@@ -4,6 +4,6 @@ source /opt/jdk_switcher/jdk_switcher.sh
 
 ./dspot-prettifer/src/test/bash/install_code2vec.sh
 
-pip3 install bottleneck numpy keras tensorflow
+pip3 install --quiet bottleneck numpy keras tensorflow
 
 jdk_switcher use openjdk8 & mvn -Djava.src.version=1.8 test -f dspot-prettifier/pom.xml


### PR DESCRIPTION
The job errored because there was too much log output.
I've set the pip install to quiet and now the job should no longer be aborted 😃