### PR TITLE
Doc: add link to DSpot IntelliJ plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ DSpot ecosystem:
 
 * [Jenkins plugin](https://github.com/STAMP-project/dspot-jenkins-plugin)
 * [Eclipse plugin](https://github.com/STAMP-project/stamp-ide)
+* [IntelliJ plugin](https://github.com/TestShiftProject/test-cube)
 * Travis integration: TBD
 
 ## Getting started


### PR DESCRIPTION
Drive-by doc improvement suggestion - linking in IntelliJ plugin developed by @lacinoire.