### PR TITLE
refactor: remove dependency to unsupported library log4j 1.2

### DIFF
--- a/dspot/pom.xml
+++ b/dspot/pom.xml
@@ -62,9 +62,9 @@
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
-            <scope>compile</scope>
+            <scope>test</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.jacoco/org.jacoco.core -->


### PR DESCRIPTION
log4j1.2 is not [supported anymore](http://logging.apache.org/log4j/1.2/index.html) since 2015