### PR TITLE
Developer-Oriented Amplification for  the Test Cube Plugin

### DIFF
--- a/.github/workflows/mvn-build-dspot-action.yml
+++ b/.github/workflows/mvn-build-dspot-action.yml
@@ -1,6 +1,6 @@
 name: DSpot CI
 
-on: [pull_request]
+on: [pull_request,workflow_dispatch]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ java -jar /path/to/dspot-LATEST-jar-with-dependencies.jar --absolute-path-to-pro
 ### Command line options
 
 ```
-Usage: eu.stamp_project.Main [-hvV] [--allow-path-in-assertions] [--clean] [--example] [--execute-test-parallel]
-                             [--generate-new-test-class] [--gregor-mode] [--keep-original-test-methods]
-                             [--only-input-amplification] [--restful] [--smtp-auth] [--target-one-test-class]
-                             [--use-maven-to-exe-test] [--use-working-directory] [--with-comment]
+Usage: eu.stamp_project.Main [-hvV] [--allow-path-in-assertions] [--clean] [--dev-friendly] [--example]
+                             [--execute-test-parallel] [--generate-new-test-class] [--gregor-mode]
+                             [--keep-original-test-methods] [--only-input-amplification] [--restful] [--smtp-auth]
+                             [--target-one-test-class] [--use-maven-to-exe-test] [--use-working-directory]
                              [--absolute-path-to-project-root=<absolutePathToProjectRoot>]
                              [--absolute-path-to-second-version=<absolutePathToSecondVersionProjectRoot>]
                              [--automatic-builder=<automaticBuilder>] [--cache-size=<cacheSize>]
@@ -146,9 +146,9 @@ Usage: eu.stamp_project.Main [-hvV] [--allow-path-in-assertions] [--clean] [--ex
                              [--repo-slug=<repoSlug>] [-s=<selector>] [--smtp-host=<smtpHost>]
                              [--smtp-password=<smtpPassword>] [--smtp-port=<smtpPort>] [--smtp-tls=<smtpTls>]
                              [--smtp-username=<smtpUsername>] [--system-properties=<systemProperties>]
-                             [--target-module=<targetModule>] [--time-out=<timeOutInMs>] [-a=<amplifiers>[,
-                             <amplifiers>...]]... [-c=<testCases>[,<testCases>...]]... [-t=<testClasses>[,
-                             <testClasses>...]]...
+                             [--target-module=<targetModule>] [--time-out=<timeOutInMs>] [--with-comment=<withComment>]
+                             [-a=<amplifiers>[,<amplifiers>...]]... [-c=<testCases>[,<testCases>...]]...
+                             [-t=<testClasses>[,<testClasses>...]]...
   -a, --amplifiers=<amplifiers>[,<amplifiers>...]
                              Specify the list of amplifiers to use. By default, DSpot does not use any amplifiers
                                (None) and applies only assertion amplification. Valid values:
@@ -188,6 +188,8 @@ Usage: eu.stamp_project.Main [-hvV] [--allow-path-in-assertions] [--clean] [--ex
                                com/STAMP-project/pitest-descartes
       --descartes-version=<descartesVersion>
                              Specify the version of pit-descartes to use. Default value: 1.2.4
+      --dev-friendly         Amplifies the test cases in a way that is easy for developers to read and understand.
+                               Default value: false
       --example              Run the example of DSpot and leave.
       --excluded-classes=<excludedClasses>
                              Specify the full qualified name of excluded test classes. Each qualified name must be
@@ -301,8 +303,8 @@ Usage: eu.stamp_project.Main [-hvV] [--allow-path-in-assertions] [--clean] [--ex
                                a completely new one. Default value: false
   -s, --test-selector, --test-criterion=<selector>
                              Specify the test adequacy criterion to be maximized with amplification. Valid values:
-                               PitMutantScoreSelector, JacocoCoverageSelector, TakeAllSelector, ChangeDetectorSelector
-                               Default value: PitMutantScoreSelector
+                               PitMutantScoreSelector, JacocoCoverageSelector, TakeAllSelector, ChangeDetectorSelector,
+                               ExtendedCoverageSelector Default value: PitMutantScoreSelector
       --smtp-auth            Enable this if the smtp host server require auth. Default value: false
       --smtp-host=<smtpHost> Host server name. Default value: smtp.gmail.com
       --smtp-password=<smtpPassword>
@@ -335,7 +337,9 @@ Usage: eu.stamp_project.Main [-hvV] [--allow-path-in-assertions] [--clean] [--ex
                                value: false
   -v, --verbose              Enable verbose mode of DSpot. Default value: false
   -V, --version              Print version information and exit.
-      --with-comment         Enable comment on amplified test: details steps of the Amplification. Default value: falseg
+      --with-comment=<withComment>
+                             Enable comment on amplified test: details steps of the amplification. Valid values: All,
+                               Amplifier, Coverage, None. Default value: None
 ```
     
 For options that take list, the used separator is a comma `,`, whatever the platform you use.
@@ -382,10 +386,11 @@ In **DSpot**, test selectors can be seen as a fitness: it measures the quality o
 The
 The default selector is `PitMutantScoreSelector`. This selector is based on [**PIT**](http://pitest.org/), which is a tool to computation mutation analysis. **DSpot** will keep only tests that increase the mutation score.
 
-Following the list of avalaible test selector:
+Following the list of available test selectors:
 
    * `PitMutantScoreSelector`: uses [**PIT**](http://pitest.org/) to computes the mutation score, and selects amplified tests that kill mutants that was not kill by the original test suite.
    * `JacocoCoverageSelector`: uses [**JaCoCo**](http://www.eclemma.org/jacoco/) to compute instruction coverage and executed paths (the order matters). Selects test that increase the coverage and has unique executed path.
+   * `ExtendedCoverageSelector`: uses [**JaCoCo**](http://www.eclemma.org/jacoco/) to compute instruction coverage. Selects tests that cover more instructions than the original test suite on any line of the code under test.
    * `TakeAllSelector`: keeps all amplified tests not matter the quality.
    * `ChangeDetectorSelector`: runs against a second version of the same program, and selects amplified tests that fail. This selector selects only amplified test that are able to show a difference of a behavior betweeen two versions of the same program.
 
@@ -393,7 +398,7 @@ Following the list of avalaible test selector:
 
 In **DSpot**, the Input Ampl Distributor is a way to select the amplified test methods after the input amplification. It allows to keep interesting and discard unwanted amplified test method.
 
-For now, there is two implementation of the Input Ampl Distributor:
+For now, there are three implementations of the Input Ampl Distributor:
 
    * `RandomInputAmplDistributor`: This distributor selects randonly amplified test methods.
    * `TextualDistanceInputAmplDistributor`: This distributor selects by maximize their distance of string representation among all the input amplified test methods. The number of amplified selected test methods is specified by the command line option `--max-test-amplified`.

--- a/dspot/pom.xml
+++ b/dspot/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>eu.stamp-project</groupId>
             <artifactId>test-runner</artifactId>
-            <version>2.1.1</version>
+            <version>2.3.0-SNAPSHOT</version>
             <classifier>jar-with-dependencies</classifier>
         </dependency>
 

--- a/dspot/pom.xml
+++ b/dspot/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>eu.stamp-project</groupId>
             <artifactId>test-runner</artifactId>
-            <version>2.3.0-SNAPSHOT</version>
+            <version>2.3.0</version>
             <classifier>jar-with-dependencies</classifier>
         </dependency>
 
@@ -289,6 +289,10 @@
                         </exclude> <!-- disabled selector -->
                         <exclude>**/com/atlassian/clover/reporters/html/*
                         </exclude> <!-- we override this class to get specific information -->
+                        <exclude>**/testwithloggenerator/objectlogsyntaxbuilder_constructs/objectlog/*
+                        </exclude> <!-- clash with non-.class of same name -->
+                        <exclude>**/testwithloggenerator/objectlogsyntaxbuilder_constructs/ObjectLog.*
+                        </exclude> <!-- clash with non-.class of same name -->
                     </excludes>
                 </configuration>
             </plugin>

--- a/dspot/src/main/java/eu/stamp_project/dspot/DevFriendlyAmplification.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/DevFriendlyAmplification.java
@@ -1,0 +1,152 @@
+package eu.stamp_project.dspot;
+
+import eu.stamp_project.dspot.common.configuration.AmplificationSetup;
+import eu.stamp_project.dspot.common.configuration.DSpotState;
+import eu.stamp_project.dspot.common.configuration.TestTuple;
+import eu.stamp_project.dspot.common.miscellaneous.AmplificationException;
+import eu.stamp_project.dspot.common.report.GlobalReport;
+import eu.stamp_project.dspot.common.report.error.Error;
+import eu.stamp_project.testrunner.EntryPoint;
+import org.slf4j.Logger;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static eu.stamp_project.dspot.common.report.error.ErrorEnum.ERROR_ASSERT_AMPLIFICATION;
+
+public class DevFriendlyAmplification {
+
+    private final DSpot dSpot;
+    private final DSpotState dSpotState;
+    private final AmplificationSetup setup;
+    private final Logger LOGGER;
+    private final GlobalReport GLOBAL_REPORT;
+
+    public DevFriendlyAmplification(DSpot dSpot, DSpotState dSpotState, AmplificationSetup setup, Logger LOGGER,
+                                    GlobalReport GLOBAL_REPORT) {
+        this.dSpot = dSpot;
+        this.dSpotState = dSpotState;
+        this.setup = setup;
+        this.LOGGER = LOGGER;
+        this.GLOBAL_REPORT = GLOBAL_REPORT;
+    }
+
+    /**
+     * Amplifies the test cases in a way suitable to present the results to developers.
+     *
+     * @param testClassToBeAmplified   Test class to be amplified
+     * @param testMethodsToBeAmplified Test methods to be amplified
+     * @return Amplified test methods
+     */
+    public List<CtMethod<?>> devFriendlyAmplification(CtType<?> testClassToBeAmplified,
+                                                      List<CtMethod<?>> testMethodsToBeAmplified) {
+
+        final List<CtMethod<?>> selectedToBeAmplified = dSpot
+                .setupSelector(testClassToBeAmplified,
+                        dSpotState.getTestFinder().findTestMethods(testClassToBeAmplified,Collections.emptyList()));
+
+        // selectedToBeAmplified with all test class methods -> keep only ones matching testMethodsToBeAmplified
+        final List<CtMethod<?>> methodsToAmplify =
+                selectedToBeAmplified.stream().filter(testMethodsToBeAmplified::contains).collect(Collectors.toList());
+
+        final List<CtMethod<?>> amplifiedTestMethodsToKeep = new ArrayList<>();
+        amplifiedTestMethodsToKeep.addAll(ampRemoveAssertionsAddNewOnes(testClassToBeAmplified, methodsToAmplify));
+        amplifiedTestMethodsToKeep.addAll(inputAmplification(testClassToBeAmplified, methodsToAmplify));
+        return amplifiedTestMethodsToKeep;
+    }
+
+    /**
+     * Path 1 of dev-friendly amplification: remove old assertions (if at the end of test case: completely, also
+     * invocations inside assertions are removed) and then add single new assertions.
+     * @param testClassToBeAmplified original test class
+     * @param testMethodsToBeAmplified original test methods
+     * @return amplified test methods
+     */
+    public List<CtMethod<?>> ampRemoveAssertionsAddNewOnes(CtType<?> testClassToBeAmplified,
+                                                           List<CtMethod<?>> testMethodsToBeAmplified) {
+        final List<CtMethod<?>> amplifiedTests;
+        final CtType<?> classWithTestMethods;
+        try {
+            TestTuple testTuple;
+            // Remove old assertions
+            testTuple = dSpotState.getAssertionGenerator()
+                    .removeAssertions(testClassToBeAmplified, testMethodsToBeAmplified);
+
+            // Add new assertions
+            amplifiedTests = dSpotState.getAssertionGenerator()
+                    .assertionAmplification(testTuple.testClassToBeAmplified, testTuple.testMethodsToBeAmplified);
+            classWithTestMethods = testTuple.testClassToBeAmplified;
+        } catch (Exception | java.lang.Error e) {
+            GLOBAL_REPORT.addError(new Error(ERROR_ASSERT_AMPLIFICATION, e));
+            return Collections.emptyList();
+        }
+
+        return selectPassingAndImprovingTests(amplifiedTests,classWithTestMethods,1);
+    }
+
+    /**
+     * Path 2 of dev-friendly amplification: remove old assertions, amplify inputs and then add new assertions.
+     * The new assertions assert values that changed through the input amplification.
+     * @param testClassToBeAmplified original test class
+     * @param testMethodsToBeAmplified original test methods
+     * @return amplified test methods
+     */
+    public List<CtMethod<?>> inputAmplification(CtType<?> testClassToBeAmplified,
+                                                List<CtMethod<?>> testMethodsToBeAmplified) {
+        final List<CtMethod<?>> amplifiedTests;
+        final CtType<?> classWithTestMethods;
+        try {
+            TestTuple testTuple;
+            // Remove old assertions
+            testTuple = dSpotState.getAssertionGenerator()
+                    .removeAssertions(testClassToBeAmplified, testMethodsToBeAmplified);
+            classWithTestMethods = testTuple.testClassToBeAmplified;
+
+            // Amplify input
+            List<CtMethod<?>> selectedForInputAmplification = setup
+                    .fullSelectorSetup(classWithTestMethods, testTuple.testMethodsToBeAmplified);
+
+            List<CtMethod<?>> inputAmplifiedTests = dSpotState.getInputAmplDistributor()
+                    .inputAmplify(selectedForInputAmplification, 0);
+
+            // Add new assertions
+            amplifiedTests = dSpotState.getAssertionGenerator()
+                    .assertionAmplification(classWithTestMethods, inputAmplifiedTests);
+
+        } catch (Exception | java.lang.Error e) {
+            GLOBAL_REPORT.addError(new Error(ERROR_ASSERT_AMPLIFICATION, e));
+            return Collections.emptyList();
+        }
+
+        return selectPassingAndImprovingTests(amplifiedTests,classWithTestMethods,2);
+    }
+
+    private List<CtMethod<?>> selectPassingAndImprovingTests(List<CtMethod<?>> amplifiedTests,
+                                                             CtType<?> classWithTestMethods,
+                                                             int path) {
+        if (amplifiedTests.isEmpty()) {
+            return Collections.emptyList();
+        }
+        final List<CtMethod<?>> amplifiedPassingTests = dSpotState.getTestCompiler()
+                .compileRunAndDiscardUncompilableAndFailingTestMethods(classWithTestMethods, amplifiedTests, dSpotState
+                        .getCompiler());
+
+        // Keep tests that improve the test suite
+        final List<CtMethod<?>> improvingTests = new ArrayList<>();
+        try {
+            dSpot.selectImprovingTestCases(amplifiedPassingTests, improvingTests);
+        } catch (AmplificationException e) {
+            GLOBAL_REPORT.addError(new Error(ERROR_ASSERT_AMPLIFICATION, e));
+            return Collections.emptyList();
+        }
+
+        LOGGER.info("Dev friendly amplification, path {}: {} test method(s) have been successfully amplified.",
+                path, improvingTests.size());
+        return improvingTests;
+    }
+
+}

--- a/dspot/src/main/java/eu/stamp_project/dspot/DevFriendlyAmplification.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/DevFriendlyAmplification.java
@@ -6,7 +6,6 @@ import eu.stamp_project.dspot.common.configuration.TestTuple;
 import eu.stamp_project.dspot.common.miscellaneous.AmplificationException;
 import eu.stamp_project.dspot.common.report.GlobalReport;
 import eu.stamp_project.dspot.common.report.error.Error;
-import eu.stamp_project.testrunner.EntryPoint;
 import org.slf4j.Logger;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;

--- a/dspot/src/main/java/eu/stamp_project/dspot/amplifier/amplifiers/AmplifierHelper.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/amplifier/amplifiers/AmplifierHelper.java
@@ -2,6 +2,7 @@ package eu.stamp_project.dspot.amplifier.amplifiers;
 
 import eu.stamp_project.dspot.amplifier.amplifiers.value.ValueCreator;
 import eu.stamp_project.dspot.amplifier.amplifiers.value.ValueCreatorHelper;
+import eu.stamp_project.dspot.common.configuration.options.CommentEnum;
 import eu.stamp_project.dspot.common.miscellaneous.CloneHelper;
 import eu.stamp_project.dspot.amplifier.amplifiers.utils.RandomHelper;
 import eu.stamp_project.dspot.common.miscellaneous.DSpotUtils;
@@ -95,7 +96,7 @@ public class AmplifierHelper {
                     localVariable = ValueCreator.createRandomLocalVar(parameter.getType(), parameter.getSimpleName());
                 }
                 body.insertBegin(localVariable);
-                DSpotUtils.addComment(localVariable, comment, CtComment.CommentType.INLINE);
+                DSpotUtils.addComment(localVariable, comment, CtComment.CommentType.INLINE, CommentEnum.Amplifier);
                 arguments.add(factory.createVariableRead(localVariable.getReference(), false));
             } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -103,7 +104,7 @@ public class AmplifierHelper {
         });
         CtExpression targetClone = target.clone();
         CtInvocation newInvocation = factory.Code().createInvocation(targetClone, methodToInvokeToAdd.getReference(), arguments);
-        DSpotUtils.addComment(newInvocation, comment, CtComment.CommentType.INLINE);
+        DSpotUtils.addComment(newInvocation, comment, CtComment.CommentType.INLINE, CommentEnum.Amplifier);
         body.insertEnd(newInvocation);
         return methodClone;
     }

--- a/dspot/src/main/java/eu/stamp_project/dspot/amplifier/amplifiers/FastLiteralAmplifier.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/amplifier/amplifiers/FastLiteralAmplifier.java
@@ -2,6 +2,7 @@
 
 package eu.stamp_project.dspot.amplifier.amplifiers;
 
+import eu.stamp_project.dspot.common.configuration.options.CommentEnum;
 import eu.stamp_project.dspot.common.test_framework.TestFramework;
 import eu.stamp_project.dspot.amplifier.amplifiers.utils.AmplificationChecker;
 import eu.stamp_project.dspot.common.miscellaneous.AmplificationHelper;
@@ -248,6 +249,6 @@ public class FastLiteralAmplifier implements Amplifier {
 	}
 
 	private void addComment(CtElement element, String kind, Object oldValue, Object newValue) {
-		DSpotUtils.addComment(element, "FastLiteralAmplifier: change " + kind + " from '" + oldValue + "' to '" + newValue + "'", CtComment.CommentType.INLINE);
+		DSpotUtils.addComment(element, "FastLiteralAmplifier: change " + kind + " from '" + oldValue + "' to '" + newValue + "'", CtComment.CommentType.INLINE, CommentEnum.Amplifier);
 	}
 }

--- a/dspot/src/main/java/eu/stamp_project/dspot/amplifier/amplifiers/MethodDuplicationAmplifier.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/amplifier/amplifiers/MethodDuplicationAmplifier.java
@@ -1,5 +1,6 @@
 package eu.stamp_project.dspot.amplifier.amplifiers;
 
+import eu.stamp_project.dspot.common.configuration.options.CommentEnum;
 import eu.stamp_project.dspot.common.miscellaneous.DSpotUtils;
 import eu.stamp_project.dspot.common.test_framework.TestFramework;
 import eu.stamp_project.dspot.amplifier.amplifiers.utils.AmplificationChecker;
@@ -51,7 +52,10 @@ public class MethodDuplicationAmplifier implements Amplifier {
         removeAllTypeCast(invocationToBeInserted);
         final CtStatement insertionPoint = this.getRightInsertionPoint(invocation);
         insertionPoint.insertBefore(invocationToBeInserted);
-        DSpotUtils.addComment(invocationToBeInserted, "MethodDuplicationAmplifier: duplicated method call", CtComment.CommentType.INLINE);
+        DSpotUtils.addComment(invocationToBeInserted,
+                "MethodDuplicationAmplifier: duplicated method call",
+                CtComment.CommentType.INLINE,
+                CommentEnum.Amplifier);
         final CtMethod<?> clone = CloneHelper.cloneTestMethodForAmp(method, "_add");
         AmplifierHelper.getParent(invocationToBeInserted).getStatements().remove(invocationToBeInserted);
         Counter.updateInputOf(clone, 1);

--- a/dspot/src/main/java/eu/stamp_project/dspot/amplifier/amplifiers/ReturnValueAmplifier.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/amplifier/amplifiers/ReturnValueAmplifier.java
@@ -1,5 +1,6 @@
 package eu.stamp_project.dspot.amplifier.amplifiers;
 
+import eu.stamp_project.dspot.common.configuration.options.CommentEnum;
 import eu.stamp_project.dspot.common.miscellaneous.CloneHelper;
 import eu.stamp_project.dspot.common.miscellaneous.Counter;
 import eu.stamp_project.dspot.common.miscellaneous.DSpotUtils;
@@ -53,7 +54,10 @@ public class ReturnValueAmplifier implements Amplifier {
                         methodClone.getElements(new TypeFilter<>(CtStatement.class)).get(indexOfInvocation),
                         localVar
                 );
-                DSpotUtils.addComment(localVar, "StatementAdd: generate variable from return value", CtComment.CommentType.INLINE);
+                DSpotUtils.addComment(localVar,
+                        "StatementAdd: generate variable from return value",
+                        CtComment.CommentType.INLINE,
+                        CommentEnum.Amplifier);
                 ampMethods.addAll(methodsWithTargetType.stream()
                         .map(addMth -> AmplifierHelper.addInvocation(methodClone, addMth, target, localVar, "_rv", "ReturnValueAmplifier: add method call"))
                         .collect(Collectors.toList()));

--- a/dspot/src/main/java/eu/stamp_project/dspot/assertiongenerator/assertiongenerator/AssertionRemover.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/assertiongenerator/assertiongenerator/AssertionRemover.java
@@ -64,6 +64,28 @@ public class AssertionRemover {
     }
 
     /**
+     * Can be called after {@link AssertionRemover#removeAssertion(CtMethod)} to remove the statements that
+     * previously were arguments of assertions all the way at
+     * @param testMethod
+     * @return
+     */
+    public CtMethod<?> removeArgumentsOfTrailingAssertions(CtMethod<?> testMethod) {
+        List<CtStatement> testStatements = testMethod.getElements(new TypeFilter<>(CtStatement.class));
+
+        for (int i = testStatements.size() - 1; i >= 0; i--) {
+            CtStatement statement = testStatements.get(i);
+            Object metadata = statement.getMetadata(AssertionGeneratorUtils.METADATA_WAS_IN_ASSERTION);
+            if (metadata != null && (Boolean) metadata) {
+                testMethod.getBody().removeStatement(statement);
+            } else {
+                break;
+            }
+        }
+
+        return testMethod;
+    }
+
+    /**
      * Replaces an invocation with its arguments.
      *
      * @param invocation Invocation

--- a/dspot/src/main/java/eu/stamp_project/dspot/assertiongenerator/assertiongenerator/methodreconstructor/Observer.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/assertiongenerator/assertiongenerator/methodreconstructor/Observer.java
@@ -15,6 +15,8 @@ import org.slf4j.LoggerFactory;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
+
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +68,14 @@ public class Observer {
         final List<CtMethod<?>> testCasesWithLogs;
         testCasesWithLogs = addLogs(testCases);
         final List<CtMethod<?>> testsToRun = setupTests(testCasesWithLogs,clone);
+
+        File observationOutputPath = new File("target/dspot");
+        if (!observationOutputPath.exists()) {
+            if (!observationOutputPath.mkdirs()) {
+                LOGGER.error("Could not create observation.ser output directory!");
+            }
+        }
+
         return compileRunTests(clone,testsToRun);
     }
 

--- a/dspot/src/main/java/eu/stamp_project/dspot/assertiongenerator/assertiongenerator/methodreconstructor/observer/TestWithLogGenerator.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/assertiongenerator/assertiongenerator/methodreconstructor/observer/TestWithLogGenerator.java
@@ -38,6 +38,7 @@ public class TestWithLogGenerator {
         allStatement.stream()
                 .filter(statement ->
                         (TestWithLogGenerator.isStmtToLog(filter, statement) ||
+                                ctVariableReads != null &&
                                 ctVariableReads.contains(statement)) &&
                                 isNotFromPreviousAmplification(allStatement, statement, test)
                 ).forEach(statement ->

--- a/dspot/src/main/java/eu/stamp_project/dspot/common/compilation/TestCompiler.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/common/compilation/TestCompiler.java
@@ -80,10 +80,10 @@ public class TestCompiler {
      * @param currentTestList test methods to be run
      * @return Results of tests' run
      */
-    public List<CtMethod<?>> compileRunAndDiscardUncompilableAndFailingTestMethods(CtType classTest,
+    public List<CtMethod<?>> compileRunAndDiscardUncompilableAndFailingTestMethods(CtType<?> classTest,
                                                                                     List<CtMethod<?>> currentTestList,
                                                                                     DSpotCompiler compiler) {
-        CtType amplifiedTestClass = CloneHelper.cloneTestClassAndAddGivenTest(classTest, currentTestList);
+        CtType<?> amplifiedTestClass = CloneHelper.cloneTestClassAndAddGivenTest(classTest, currentTestList);
         try {
             final TestResult result = this.compileAndRun(
                     amplifiedTestClass,

--- a/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/AmplificationSetup.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/AmplificationSetup.java
@@ -13,6 +13,7 @@ import eu.stamp_project.dspot.common.report.GlobalReport;
 import eu.stamp_project.dspot.common.report.error.Error;
 import eu.stamp_project.dspot.common.report.output.Output;
 import eu.stamp_project.dspot.common.report.output.selector.TestSelectorElementReport;
+import eu.stamp_project.testrunner.runner.ParserOptions;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import spoon.reflect.declaration.CtMethod;
@@ -63,6 +64,9 @@ public class AmplificationSetup {
         final boolean jUnit5 = TestFramework.isJUnit5(testMethodsToBeAmplified.get(0));
         EntryPoint.jUnit5Mode = jUnit5;
         DSpotPOMCreator.isCurrentlyJUnit5 = jUnit5;
+        if (dSpotState.isDevFriendlyAmplification()) {
+            EntryPoint.coverageDetail = ParserOptions.CoverageTransformerDetail.METHOD_DETAIL;
+        }
         Counter.reset();
         if (dSpotState.shouldGenerateAmplifiedTestClass()) {
             testClassToBeAmplified = AmplificationHelper.renameTestClassUnderAmplification(testClassToBeAmplified);
@@ -113,7 +117,8 @@ public class AmplificationSetup {
         }
     }
 
-    public List<CtMethod<?>> firstSelectorSetup(CtType<?> testClassToBeAmplified, List<CtMethod<?>> testMethodsToBeAmplified)
+    public List<CtMethod<?>> firstSelectorSetup(CtType<?> testClassToBeAmplified,
+                                                 List<CtMethod<?>> testMethodsToBeAmplified)
             throws Exception {
         if(testMethodsToBeAmplified.isEmpty()) {
             LOGGER.warn("No test provided for amplification in class {}", testClassToBeAmplified.getQualifiedName());

--- a/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/DSpotState.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/DSpotState.java
@@ -35,6 +35,7 @@ public class DSpotState {
     private TestSelector testSelector;
     private InputAmplDistributor inputAmplDistributor;
     private boolean onlyInputAmplification;
+    private boolean devFriendlyAmplification;
     private Output output;
     private Collector collector;
     private boolean collectData;
@@ -63,7 +64,7 @@ public class DSpotState {
      * it is cleared before iterating again for next test class.
      */
     public void clearData(){
-        this.assertionGenerator = new AssertionGenerator(delta, this.compiler, this.testCompiler);
+        this.assertionGenerator = new AssertionGenerator(delta, this.compiler, this.testCompiler, this.devFriendlyAmplification);
     }
 
     public boolean isOnlyInputAmplification() {
@@ -72,6 +73,14 @@ public class DSpotState {
 
     public void setOnlyInputAmplification(boolean onlyInputAmplification) {
         this.onlyInputAmplification = onlyInputAmplification;
+    }
+
+    public boolean isDevFriendlyAmplification() {
+        return devFriendlyAmplification;
+    }
+
+    public void setDevFriendlyAmplification(boolean devFriendlyAmplification) {
+        this.devFriendlyAmplification = devFriendlyAmplification;
     }
 
     public int getNbIteration() {

--- a/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/InitializeDSpot.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/InitializeDSpot.java
@@ -39,6 +39,7 @@ public class InitializeDSpot {
         this.DSpotState = new DSpotState();
         DSpotState.setUserInput(userInput);
         DSpotState.setOnlyInputAmplification(userInput.isOnlyInputAmplification());
+        DSpotState.setDevFriendlyAmplification(userInput.isDevFriendlyAmplification());
         DSpotState.verbose = userInput.isVerbose();
         DSpotState.setStartTime(System.currentTimeMillis());
         DSpotState.setTestFinder(new TestFinder(
@@ -101,7 +102,7 @@ public class InitializeDSpot {
                 DSpotState.getCollector()
 
         ));
-        DSpotState.setAssertionGenerator(new AssertionGenerator(userInput.getDelta(), DSpotState.getCompiler(), DSpotState.getTestCompiler()));
+        DSpotState.setAssertionGenerator(new AssertionGenerator(userInput.getDelta(), DSpotState.getCompiler(), DSpotState.getTestCompiler(), DSpotState.isDevFriendlyAmplification()));
         Checker.postChecking(userInput);
         DSpotState.setCollectData(true);
         DSpotState.setDelta(userInput.getDelta());

--- a/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/UserInput.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/UserInput.java
@@ -23,6 +23,13 @@ import static eu.stamp_project.dspot.common.miscellaneous.AmplificationHelper.PA
  * given by the user.
  * Created by marcel on 8/06/14.
  * This version of the UserInput has been largely modified, and customized to be use in DSpot.
+ *
+ *
+ * To add a new option to DSpot, you likely need to add it at the following places:
+ *  - below here as a `@CommandLine.Option` private attribute
+ *  - further down here as a getter & setter
+ *  - as a private attribute in {@link DSpotState}, including getter & setter
+ *  - set it's value in {@link InitializeDSpot#init(UserInput)}.
  */
 @CommandLine.Command(name = "eu.stamp_project.Main", mixinStandardHelpOptions = true)
 public class UserInput {
@@ -154,6 +161,14 @@ public class UserInput {
                     " Default value: ${DEFAULT-VALUE}"
     )
     private boolean onlyInputAmplification;
+
+    @CommandLine.Option(
+            names = "--dev-friendly",
+            defaultValue = "false",
+            description = "Amplifies the test cases in a way that is easy for developers to read and understand."+
+                    " Default value: ${DEFAULT-VALUE}"
+    )
+    private boolean devFriendlyAmplification;
 
     /*
         advanced amplification process configuration
@@ -413,11 +428,12 @@ public class UserInput {
 
     @CommandLine.Option(
             names = {"--with-comment"},
-            defaultValue = "false",
-            description = "Enable comment on amplified test: details steps of the Amplification." +
+            defaultValue = "None",
+            description = "Enable comment on amplified test: details steps of the amplification." +
+                    " Valid values: ${COMPLETION-CANDIDATES}." +
                     " Default value: ${DEFAULT-VALUE}"
     )
-    private boolean withComment;
+    private CommentEnum withComment;
 
     @CommandLine.Option(
             names = {"--allow-path-in-assertions"},
@@ -595,6 +611,15 @@ public class UserInput {
 
     public UserInput setOnlyInputAmplification(boolean onlyInputAmplification) {
         this.onlyInputAmplification = onlyInputAmplification;
+        return this;
+    }
+
+    public boolean isDevFriendlyAmplification() {
+        return devFriendlyAmplification;
+    }
+
+    public UserInput setDevFriendlyAmplification(boolean devFriendlyAmplification) {
+        this.devFriendlyAmplification = devFriendlyAmplification;
         return this;
     }
 
@@ -912,7 +937,7 @@ public class UserInput {
         return this;
     }
 
-    public boolean withComment() {
+    public CommentEnum withComment() {
         return withComment;
     }
 

--- a/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/options/CommentEnum.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/options/CommentEnum.java
@@ -1,0 +1,8 @@
+package eu.stamp_project.dspot.common.configuration.options;
+
+public enum CommentEnum {
+    All,
+    Amplifier,
+    Coverage,
+    None
+}

--- a/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/options/SelectorEnum.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/common/configuration/options/SelectorEnum.java
@@ -2,11 +2,7 @@ package eu.stamp_project.dspot.common.configuration.options;
 
 import eu.stamp_project.dspot.common.automaticbuilder.AutomaticBuilder;
 import eu.stamp_project.dspot.common.configuration.UserInput;
-import eu.stamp_project.dspot.selector.ChangeDetectorSelector;
-import eu.stamp_project.dspot.selector.JacocoCoverageSelector;
-import eu.stamp_project.dspot.selector.PitMutantScoreSelector;
-import eu.stamp_project.dspot.selector.TakeAllSelector;
-import eu.stamp_project.dspot.selector.TestSelector;
+import eu.stamp_project.dspot.selector.*;
 
 public enum SelectorEnum {
     PitMutantScoreSelector {
@@ -31,6 +27,12 @@ public enum SelectorEnum {
         @Override
         public TestSelector buildSelector(AutomaticBuilder builder, UserInput configuration) {
             return new ChangeDetectorSelector(builder, configuration);
+        }
+    },
+    ExtendedCoverageSelector {
+        @Override
+        public TestSelector buildSelector(AutomaticBuilder builder, UserInput configuration) {
+            return new ExtendedCoverageSelector(builder, configuration);
         }
     };
 

--- a/dspot/src/main/java/eu/stamp_project/dspot/common/miscellaneous/AmplificationHelper.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/common/miscellaneous/AmplificationHelper.java
@@ -3,7 +3,6 @@ package eu.stamp_project.dspot.common.miscellaneous;
 import eu.stamp_project.dspot.common.configuration.options.CommentEnum;
 import eu.stamp_project.dspot.common.test_framework.TestFramework;
 import eu.stamp_project.testrunner.listener.TestResult;
-
 import org.apache.cxf.common.util.WeakIdentityHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,7 +15,6 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.TypeFilter;
 
-import javax.swing.event.ListDataEvent;
 import java.text.DecimalFormat;
 import java.util.*;
 import java.util.regex.Pattern;

--- a/dspot/src/main/java/eu/stamp_project/dspot/common/report/output/selector/extendedcoverage/json/TestCaseJSON.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/common/report/output/selector/extendedcoverage/json/TestCaseJSON.java
@@ -1,0 +1,42 @@
+package eu.stamp_project.dspot.common.report.output.selector.extendedcoverage.json;
+
+import eu.stamp_project.dspot.selector.extendedcoverageselector.CoverageImprovement;
+import eu.stamp_project.dspot.selector.extendedcoverageselector.ExtendedCoverage;
+
+public class TestCaseJSON {
+
+    private final String name;
+    private final int nbAssertionAdded;
+    private final int nbInputAdded;
+    private final CoverageImprovement coverageImprovement;
+    private final ExtendedCoverage fullCoverage;
+
+    public TestCaseJSON(String name, int nbAssertionAdded, int nbInputAdded, CoverageImprovement coverageImprovement,
+                        ExtendedCoverage fullCoverage) {
+        this.name = name;
+        this.nbAssertionAdded = nbAssertionAdded;
+        this.nbInputAdded = nbInputAdded;
+        this.coverageImprovement = coverageImprovement;
+        this.fullCoverage = fullCoverage;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getNbAssertionAdded() {
+        return nbAssertionAdded;
+    }
+
+    public int getNbInputAdded() {
+        return nbInputAdded;
+    }
+
+    public CoverageImprovement getCoverageImprovement() {
+        return coverageImprovement;
+    }
+
+    public ExtendedCoverage getFullCoverage() {
+        return fullCoverage;
+    }
+}

--- a/dspot/src/main/java/eu/stamp_project/dspot/common/report/output/selector/extendedcoverage/json/TestClassJSON.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/common/report/output/selector/extendedcoverage/json/TestClassJSON.java
@@ -1,0 +1,46 @@
+package eu.stamp_project.dspot.common.report.output.selector.extendedcoverage.json;
+
+import eu.stamp_project.dspot.selector.extendedcoverageselector.CoverageImprovement;
+import eu.stamp_project.dspot.selector.extendedcoverageselector.ExtendedCoverage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestClassJSON implements eu.stamp_project.dspot.common.report.output.selector.TestClassJSON {
+
+
+    private List<TestCaseJSON> testCases;
+    private final ExtendedCoverage initialCoverage;
+    private final CoverageImprovement amplifiedCoverage;
+    private final ExtendedCoverage fullCoverageAfterAmplification;
+
+    public TestClassJSON(ExtendedCoverage initialCoverage, CoverageImprovement amplifiedCoverage,
+                         ExtendedCoverage fullCoverageAfterAmplification) {
+        this.initialCoverage = initialCoverage;
+        this.amplifiedCoverage = amplifiedCoverage;
+        this.fullCoverageAfterAmplification = fullCoverageAfterAmplification;
+    }
+
+    public boolean addTestCase(TestCaseJSON testCaseJSON) {
+        if (this.testCases == null) {
+            this.testCases = new ArrayList<>();
+        }
+        return this.testCases.add(testCaseJSON);
+    }
+
+    public List<TestCaseJSON> getTestCases() {
+        return this.testCases;
+    }
+
+    public ExtendedCoverage getInitialCoverage() {
+        return initialCoverage;
+    }
+
+    public CoverageImprovement getAmplifiedCoverage() {
+        return amplifiedCoverage;
+    }
+
+    public ExtendedCoverage getFullCoverageAfterAmplification() {
+        return fullCoverageAfterAmplification;
+    }
+}

--- a/dspot/src/main/java/eu/stamp_project/dspot/common/test_framework/implementations/junit/JUnitSupport.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/common/test_framework/implementations/junit/JUnitSupport.java
@@ -2,6 +2,7 @@ package eu.stamp_project.dspot.common.test_framework.implementations.junit;
 
 import eu.stamp_project.dspot.assertiongenerator.assertiongenerator.methodreconstructor.observer.testwithloggenerator.objectlogsyntaxbuilder_constructs.ObjectLog;
 import eu.stamp_project.dspot.assertiongenerator.assertiongenerator.AssertionGeneratorUtils;
+import eu.stamp_project.dspot.common.configuration.options.CommentEnum;
 import eu.stamp_project.dspot.common.test_framework.AbstractTestFramework;
 import eu.stamp_project.dspot.common.test_framework.assertions.AssertEnum;
 import eu.stamp_project.testrunner.runner.Failure;
@@ -151,7 +152,10 @@ public abstract class JUnitSupport extends AbstractTestFramework {
             );
         }
         tryBlock.getBody().addStatement(failStatement);
-        DSpotUtils.addComment(tryBlock, "AssertionGenerator generate try/catch block with fail statement", CtComment.CommentType.INLINE);
+        DSpotUtils.addComment(tryBlock,
+                "AssertionGenerator generate try/catch block with fail statement",
+                CtComment.CommentType.INLINE,
+                CommentEnum.Amplifier);
 
         CtCatch ctCatch = factory.Core().createCatch();
         CtTypeReference exceptionType = factory.Type().createReference(failure.fullQualifiedNameOfException);

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/ExtendedCoverageSelector.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/ExtendedCoverageSelector.java
@@ -1,0 +1,118 @@
+package eu.stamp_project.dspot.selector;
+
+import eu.stamp_project.dspot.common.automaticbuilder.AutomaticBuilder;
+import eu.stamp_project.dspot.common.configuration.UserInput;
+import eu.stamp_project.dspot.common.configuration.options.CommentEnum;
+import eu.stamp_project.dspot.common.miscellaneous.AmplificationHelper;
+import eu.stamp_project.dspot.common.miscellaneous.Counter;
+import eu.stamp_project.dspot.common.miscellaneous.DSpotUtils;
+import eu.stamp_project.dspot.common.report.output.selector.TestSelectorElementReport;
+import eu.stamp_project.dspot.common.report.output.selector.TestSelectorElementReportImpl;
+import eu.stamp_project.dspot.common.report.output.selector.extendedcoverage.json.TestCaseJSON;
+import eu.stamp_project.dspot.common.report.output.selector.extendedcoverage.json.TestClassJSON;
+import eu.stamp_project.dspot.selector.extendedcoverageselector.CoverageImprovement;
+import eu.stamp_project.dspot.selector.extendedcoverageselector.ExtendedCoverage;
+import eu.stamp_project.testrunner.EntryPoint;
+import eu.stamp_project.testrunner.listener.CoveragePerTestMethod;
+import spoon.reflect.code.CtComment;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.declaration.CtType;
+
+import java.util.*;
+import java.util.concurrent.TimeoutException;
+
+public class ExtendedCoverageSelector extends TakeAllSelector {
+
+    ExtendedCoverage initialCoverage;
+
+    ExtendedCoverage cumulativeAmplifiedCoverage;
+
+    Map<CtMethod<?>, CoverageImprovement> coverageImprovementPerAmplifiedMethod;
+
+    Map<CtMethod<?>, ExtendedCoverage> fullCoveragePerAmplifiedMethod;
+
+    public ExtendedCoverageSelector(AutomaticBuilder automaticBuilder, UserInput configuration) {
+        super(automaticBuilder, configuration);
+        this.coverageImprovementPerAmplifiedMethod = new HashMap<>();
+        this.fullCoveragePerAmplifiedMethod = new HashMap<>();
+    }
+
+    @Override
+    public List<CtMethod<?>> selectToAmplify(CtType<?> classTest, List<CtMethod<?>> testsToBeAmplified) {
+        this.currentClassTestToBeAmplified = classTest;
+        // calculate existing coverage of the whole test suite
+        try {
+            this.initialCoverage = new ExtendedCoverage(EntryPoint
+                    .runCoverage(classpath + AmplificationHelper.PATH_SEPARATOR + targetClasses,
+                            this.targetClasses,
+                            this.currentClassTestToBeAmplified.getQualifiedName()));
+        } catch (TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+        this.cumulativeAmplifiedCoverage = this.initialCoverage.clone();
+        return testsToBeAmplified;
+    }
+
+    @Override
+    public List<CtMethod<?>> selectToKeep(List<CtMethod<?>> amplifiedTestToBeKept) {
+        CoveragePerTestMethod coveragePerTestMethod = computeCoverageForGivenTestMethods(amplifiedTestToBeKept);
+
+        final List<CtMethod<?>> methodsKept = new ArrayList<>();
+        for (CtMethod<?> ctMethod : amplifiedTestToBeKept) {
+            ExtendedCoverage newCoverage = new ExtendedCoverage(coveragePerTestMethod
+                    .getCoverageOf(ctMethod.getSimpleName()));
+
+            if (newCoverage.isBetterThan(this.cumulativeAmplifiedCoverage)) {
+                //note: we still explain the improvement to the coverage before amplification. Maybe we should change?
+                CoverageImprovement coverageImprovement = newCoverage.coverageImprovementOver(this.initialCoverage);
+                DSpotUtils.addComment(ctMethod, coverageImprovement.toString(), CtComment.CommentType.BLOCK, CommentEnum.Coverage);
+                methodsKept.add(ctMethod);
+                this.coverageImprovementPerAmplifiedMethod.put(ctMethod, coverageImprovement);
+                this.fullCoveragePerAmplifiedMethod.put(ctMethod, newCoverage);
+                this.cumulativeAmplifiedCoverage.accumulate(newCoverage);
+            }
+        }
+        this.selectedAmplifiedTest.addAll(methodsKept);
+
+        return methodsKept;
+    }
+
+    private CoveragePerTestMethod computeCoverageForGivenTestMethods(List<CtMethod<?>> testsToBeAmplified) {
+        final String[] methodNames = testsToBeAmplified.stream().map(CtNamedElement::getSimpleName)
+                .toArray(String[]::new);
+        try {
+            return EntryPoint.runCoveragePerTestMethods(
+                            this.classpath + AmplificationHelper.PATH_SEPARATOR + this.targetClasses,
+                            this.targetClasses,
+                            this.currentClassTestToBeAmplified.getQualifiedName(),
+                            methodNames);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public TestSelectorElementReport report() {
+        final String report = "Amplification results with " + this.selectedAmplifiedTest.size() + " new tests.";
+        return new TestSelectorElementReportImpl(report, jsonReport(), Collections.emptyList(), "");
+    }
+
+    private TestClassJSON jsonReport() {
+        TestClassJSON testClassJSON;
+        testClassJSON = new TestClassJSON(this.initialCoverage,
+                this.cumulativeAmplifiedCoverage.coverageImprovementOver(this.initialCoverage),
+                this.cumulativeAmplifiedCoverage);
+        this.selectedAmplifiedTest.stream()
+                .map(ctMethod -> new TestCaseJSON(ctMethod.getSimpleName(),
+                    Counter.getAssertionOfSinceOrigin(ctMethod),
+                    Counter.getInputOfSinceOrigin(ctMethod),
+                    this.coverageImprovementPerAmplifiedMethod.get(ctMethod),
+                    this.fullCoveragePerAmplifiedMethod.get(ctMethod)))
+                .forEach(testClassJSON::addTestCase);
+
+        return testClassJSON;
+    }
+
+
+}

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/ClassCoverageMap.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/ClassCoverageMap.java
@@ -59,8 +59,12 @@ public class ClassCoverageMap {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         ClassCoverageMap that = (ClassCoverageMap) o;
         return Objects.equals(methodCoverageMap, that.methodCoverageMap);
     }

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/ClassCoverageMap.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/ClassCoverageMap.java
@@ -1,0 +1,73 @@
+package eu.stamp_project.dspot.selector.extendedcoverageselector;
+
+import java.util.*;
+
+public class ClassCoverageMap {
+
+    public ClassCoverageMap() {
+        methodCoverageMap = new HashMap<>();
+    }
+
+    public Map<String, MethodCoverage> methodCoverageMap;
+
+    public MethodCoverage getCoverageForMethod(String methodName) {
+        return methodCoverageMap.get(methodName);
+    }
+
+    public void addMethodCoverage(String methodName, MethodCoverage methodCoverage) {
+        methodCoverageMap.put(methodName, methodCoverage);
+    }
+
+    public ClassCoverageMap improvementDiffOver(ClassCoverageMap that) {
+        ClassCoverageMap thizBetterDiff = new ClassCoverageMap();
+        for (Map.Entry<String, MethodCoverage> entry : this.methodCoverageMap.entrySet()) {
+            MethodCoverage coverageThat = that.getCoverageForMethod(entry.getKey());
+            if (coverageThat == null) {
+                thizBetterDiff.addMethodCoverage(entry.getKey(), entry.getValue());
+            } else {
+                MethodCoverage improvementDiff = entry.getValue().improvementDiffOver(coverageThat);
+                if (improvementDiff.lineCoverage.parallelStream().anyMatch(i -> i > 0)) {
+                    thizBetterDiff.addMethodCoverage(entry.getKey(), improvementDiff);
+                }
+            }
+
+        }
+        return thizBetterDiff;
+    }
+
+    public ClassCoverageMap accumulate(ClassCoverageMap toAdd) {
+        Set<String> mergedKeys = new HashSet<>();
+        mergedKeys.addAll(this.methodCoverageMap.keySet());
+        mergedKeys.addAll(toAdd.methodCoverageMap.keySet());
+
+        ClassCoverageMap accumulated = new ClassCoverageMap();
+        for (String mergedKey : mergedKeys) {
+            MethodCoverage valuesBase = this.methodCoverageMap.get(mergedKey);
+            MethodCoverage valuesToAdd = toAdd.methodCoverageMap.get(mergedKey);
+
+            if (valuesBase == null) {
+                accumulated.addMethodCoverage(mergedKey, valuesToAdd);
+            } else if (valuesToAdd == null) {
+                accumulated.addMethodCoverage(mergedKey, valuesBase);
+            } else {
+                accumulated.addMethodCoverage(mergedKey, valuesBase.accumulate(valuesToAdd));
+            }
+        }
+        return accumulated;
+
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClassCoverageMap that = (ClassCoverageMap) o;
+        return Objects.equals(methodCoverageMap, that.methodCoverageMap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(methodCoverageMap);
+    }
+}
+

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/CoverageImprovement.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/CoverageImprovement.java
@@ -1,11 +1,5 @@
 package eu.stamp_project.dspot.selector.extendedcoverageselector;
 
-import org.jacoco.core.analysis.IMethodCoverage;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 public class CoverageImprovement {
 
     public CoverageImprovement(ProjectCoverageMap instructionDiff) {

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/CoverageImprovement.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/CoverageImprovement.java
@@ -1,0 +1,50 @@
+package eu.stamp_project.dspot.selector.extendedcoverageselector;
+
+import org.jacoco.core.analysis.IMethodCoverage;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CoverageImprovement {
+
+    public CoverageImprovement(ProjectCoverageMap instructionDiff) {
+        this.instructionImprovement = instructionDiff;
+    }
+
+    public CoverageImprovement(CoverageImprovement coverageImprovement) {
+        this.instructionImprovement = coverageImprovement.getInstructionImprovement();
+    }
+
+    /**
+     * For each class name (FQ), for each line number (jacoco line with statements!) the improvement in coverage
+     */
+    protected final ProjectCoverageMap instructionImprovement;
+
+    public ProjectCoverageMap getInstructionImprovement() {
+        return instructionImprovement;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder explanation = new StringBuilder("Coverage improved at\n");
+        this.instructionImprovement.classCoverageMaps.forEach((className, classCoverageMap) -> {
+            explanation.append(className).append(":\n");
+            classCoverageMap.methodCoverageMap.forEach((methodName, methodCoverage) -> {
+                explanation.append(methodName).append("\n");
+                int index = -1;
+                for (Integer instructionImprovement : methodCoverage.lineCoverage) {
+                    index++;
+                    if (instructionImprovement <= 0) {
+                        continue;
+                    }
+                    explanation.append("L. ").append(index + 1)
+                            .append(" +").append(instructionImprovement)
+                            .append(" instr.").append("\n");
+                }
+            });
+        });
+        explanation.replace(explanation.length() - 1, explanation.length(), "");
+        return explanation.toString();
+    }
+}

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/ExtendedCoverage.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/ExtendedCoverage.java
@@ -2,9 +2,10 @@ package eu.stamp_project.dspot.selector.extendedcoverageselector;
 
 import eu.stamp_project.testrunner.listener.Coverage;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public class ExtendedCoverage {
 
@@ -21,7 +22,7 @@ public class ExtendedCoverage {
                 instructionsProjectCoverageMap.addClassCoverage(className, createClassCoverageMap(split[1]));
             }
         }
-        
+
         this.instructionsProjectCoverageMap = cleanAllZeroValuesFromMap(this.instructionsProjectCoverageMap);
     }
 
@@ -87,8 +88,12 @@ public class ExtendedCoverage {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         ExtendedCoverage that = (ExtendedCoverage) o;
         return Objects.equals(instructionsProjectCoverageMap, that.instructionsProjectCoverageMap);
     }

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/ExtendedCoverage.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/ExtendedCoverage.java
@@ -1,0 +1,109 @@
+package eu.stamp_project.dspot.selector.extendedcoverageselector;
+
+import eu.stamp_project.testrunner.listener.Coverage;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ExtendedCoverage {
+
+    private ProjectCoverageMap instructionsProjectCoverageMap;
+
+    public ExtendedCoverage(Coverage coverage) {
+
+        this.instructionsProjectCoverageMap = new ProjectCoverageMap();
+        String[] classes = coverage.getExecutionPath().split("-");
+        for (String aClass : classes) {
+            String[] split = aClass.split(":");
+            if (split.length >= 2) {
+                String className = split[0].replaceAll("/","\\.");
+                instructionsProjectCoverageMap.addClassCoverage(className, createClassCoverageMap(split[1]));
+            }
+        }
+        
+        this.instructionsProjectCoverageMap = cleanAllZeroValuesFromMap(this.instructionsProjectCoverageMap);
+    }
+
+    public ExtendedCoverage(ProjectCoverageMap instructionsProjectCoverageMap) {
+        this.instructionsProjectCoverageMap = instructionsProjectCoverageMap;
+    }
+
+    private ClassCoverageMap createClassCoverageMap(String perMethodData) {
+        ClassCoverageMap classCoverageMap = new ClassCoverageMap();
+        String[] perMethod = perMethodData.split("\\|");
+        for (String s : perMethod) {
+            String[] split = s.split("\\+");
+            String methodName = split[0];
+            String methodDescriptor = split[1];
+            List<Integer> coveredLines =
+                    Arrays.stream(split[2].split(",")).map(Integer::parseInt).collect(Collectors.toList());
+            MethodCoverage methodCoverage = new MethodCoverage(coveredLines, methodDescriptor);
+            classCoverageMap.addMethodCoverage(methodName, methodCoverage);
+        }
+        return classCoverageMap;
+    }
+
+    public ProjectCoverageMap getInstructionsProjectCoverageMap() {
+        return instructionsProjectCoverageMap;
+    }
+
+    private ProjectCoverageMap cleanAllZeroValuesFromMap(ProjectCoverageMap map) {
+        ProjectCoverageMap projectCoverageMap = new ProjectCoverageMap();
+        map.classCoverageMaps.forEach((className, classCoverage) -> {
+            ClassCoverageMap classCoverageMap = new ClassCoverageMap();
+            classCoverage.methodCoverageMap.forEach((methodName, methodCoverage) -> {
+                if (!methodCoverage.lineCoverage.stream().allMatch(i -> i == 0)) {
+                    classCoverageMap.addMethodCoverage(methodName, methodCoverage);
+                }
+            });
+            if (!classCoverageMap.methodCoverageMap.isEmpty()) {
+                projectCoverageMap.addClassCoverage(className,classCoverageMap);
+            }
+        });
+        return projectCoverageMap;
+    }
+
+    public boolean isBetterThan(ExtendedCoverage that) {
+        if (that == null) {
+            return true;
+        }
+        ProjectCoverageMap instructionDiff = this.instructionsProjectCoverageMap.improvementDiffOver(
+                that.instructionsProjectCoverageMap);
+
+        return !instructionDiff.classCoverageMaps.isEmpty();
+    }
+
+    public void accumulate(ExtendedCoverage toAdd) {
+        this.instructionsProjectCoverageMap = this.instructionsProjectCoverageMap.accumulate(
+                toAdd.instructionsProjectCoverageMap);
+    }
+
+    public CoverageImprovement coverageImprovementOver(ExtendedCoverage other) {
+        ProjectCoverageMap instructionDiff = this.instructionsProjectCoverageMap.improvementDiffOver(
+                other.instructionsProjectCoverageMap);
+        return new CoverageImprovement(instructionDiff);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ExtendedCoverage that = (ExtendedCoverage) o;
+        return Objects.equals(instructionsProjectCoverageMap, that.instructionsProjectCoverageMap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(instructionsProjectCoverageMap);
+    }
+
+    public ExtendedCoverage clone() {
+        return new ExtendedCoverage(this.instructionsProjectCoverageMap);
+    }
+
+    @Override
+    public String toString() {
+        return "ExtendedCoverage{" + "instructionsProjectCoverageMap=" + instructionsProjectCoverageMap + '}';
+    }
+}

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/MethodCoverage.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/MethodCoverage.java
@@ -1,0 +1,71 @@
+package eu.stamp_project.dspot.selector.extendedcoverageselector;
+
+import eu.stamp_project.dspot.common.configuration.TestTuple;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class MethodCoverage {
+
+    public List<Integer> lineCoverage;
+    public String methodDescriptor;
+
+    public MethodCoverage(List<Integer> lineCoverage, String methodDescriptor) {
+        this.lineCoverage = lineCoverage;
+        this.methodDescriptor = methodDescriptor;
+    }
+
+    /**
+     * calculate 'diff' of the coverage values wrt.
+     * @param that other method coverage
+     * @return coverage diff between each of the lines
+     *
+     * Only works for two method coverages from the same method (same length in number of lines)
+     */
+    public MethodCoverage improvementDiffOver(MethodCoverage that) {
+        List<Integer> betterAt = IntStream.range(0, lineCoverage.size())
+                .mapToObj(i -> lineCoverage.get(i) - that.lineCoverage.get(i))
+                .collect(Collectors.toList());
+        return new MethodCoverage(betterAt, this.methodDescriptor);
+    }
+
+    /**
+     * Only works for two method coverages from the same method (same length in number of lines)
+     */
+    public MethodCoverage accumulate(MethodCoverage toAdd) {
+        return new MethodCoverage(IntStream.range(0, this.lineCoverage.size())
+                .mapToObj(i -> Math.max(this.lineCoverage.get(i), toAdd.lineCoverage.get(i)))
+                .collect(Collectors.toList()), this.methodDescriptor);
+    }
+
+    public Map<Integer, Integer> coveragePerLine() {
+        Map<Integer, Integer> map = new HashMap<>();
+        int index = -1;
+        for (Integer instructionImprovement : lineCoverage) {
+            index++;
+            if (instructionImprovement <= 0) {
+                continue;
+            }
+            map.put(index,instructionImprovement);
+        }
+        return map;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MethodCoverage that = (MethodCoverage) o;
+        return Objects.equals(lineCoverage, that.lineCoverage) && Objects
+                .equals(methodDescriptor, that.methodDescriptor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lineCoverage, methodDescriptor);
+    }
+}

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/MethodCoverage.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/MethodCoverage.java
@@ -1,7 +1,5 @@
 package eu.stamp_project.dspot.selector.extendedcoverageselector;
 
-import eu.stamp_project.dspot.common.configuration.TestTuple;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,8 +55,12 @@ public class MethodCoverage {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         MethodCoverage that = (MethodCoverage) o;
         return Objects.equals(lineCoverage, that.lineCoverage) && Objects
                 .equals(methodDescriptor, that.methodDescriptor);

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/ProjectCoverageMap.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/ProjectCoverageMap.java
@@ -62,8 +62,12 @@ public class ProjectCoverageMap {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         ProjectCoverageMap that = (ProjectCoverageMap) o;
         return Objects.equals(classCoverageMaps, that.classCoverageMaps);
     }

--- a/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/ProjectCoverageMap.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/selector/extendedcoverageselector/ProjectCoverageMap.java
@@ -1,0 +1,95 @@
+package eu.stamp_project.dspot.selector.extendedcoverageselector;
+
+import java.util.*;
+
+public class ProjectCoverageMap {
+
+    public ProjectCoverageMap() {
+        classCoverageMaps = new HashMap<>();
+    }
+
+    public Map<String, ClassCoverageMap> classCoverageMaps;
+
+    public ClassCoverageMap getCoverageForClass(String classNameFQ) {
+        return classCoverageMaps.get(classNameFQ);
+    }
+
+    public void addClassCoverage(String classNameFQ, ClassCoverageMap classCoverageMap) {
+        classCoverageMaps.put(classNameFQ, classCoverageMap);
+    }
+
+    public ProjectCoverageMap improvementDiffOver(ProjectCoverageMap that) {
+
+        ProjectCoverageMap thizBetterDiff = new ProjectCoverageMap();
+        for (Map.Entry<String, ClassCoverageMap> entry : this.classCoverageMaps.entrySet()) {
+            ClassCoverageMap coverageThat = that.getCoverageForClass(entry.getKey());
+            if (coverageThat == null) {
+                thizBetterDiff.addClassCoverage(entry.getKey(), entry.getValue());
+            } else {
+                ClassCoverageMap improvementDiff = entry.getValue().improvementDiffOver(coverageThat);
+                if (!improvementDiff.methodCoverageMap.isEmpty()) {
+                    thizBetterDiff.addClassCoverage(entry.getKey(), improvementDiff);
+                }
+            }
+        }
+        return thizBetterDiff;
+    }
+
+    /**
+     * @param toAdd coverage map to be accumulated on top
+     * @return shared coverage of this and toAdd
+     */
+    public ProjectCoverageMap accumulate(ProjectCoverageMap toAdd) {
+        Set<String> mergedKeys = new HashSet<>();
+        mergedKeys.addAll(this.classCoverageMaps.keySet());
+        mergedKeys.addAll(toAdd.classCoverageMaps.keySet());
+
+        ProjectCoverageMap accumulated = new ProjectCoverageMap();
+        for (String mergedKey : mergedKeys) {
+            ClassCoverageMap valuesBase = this.classCoverageMaps.get(mergedKey);
+            ClassCoverageMap valuesToAdd = toAdd.classCoverageMaps.get(mergedKey);
+
+            if (valuesBase == null) {
+                accumulated.addClassCoverage(mergedKey, valuesToAdd);
+            } else if (valuesToAdd == null) {
+                accumulated.addClassCoverage(mergedKey, valuesBase);
+            } else {
+                accumulated.addClassCoverage(mergedKey, valuesBase.accumulate(valuesToAdd));
+            }
+        }
+        return accumulated;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProjectCoverageMap that = (ProjectCoverageMap) o;
+        return Objects.equals(classCoverageMaps, that.classCoverageMaps);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(classCoverageMaps);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder explanation = new StringBuilder("Project coverage map\n");
+        classCoverageMaps.forEach((className, classCoverageMap) -> {
+            explanation.append(className).append(":\n");
+            classCoverageMap.methodCoverageMap.forEach((methodName, methodCoverage) -> {
+                explanation.append(methodName).append("\n");
+                int index = -1;
+                for (Integer instructionImprovement : methodCoverage.lineCoverage) {
+                    index++;
+                    explanation.append("L. ").append(index + 1)
+                               .append(" ").append(instructionImprovement)
+                               .append(" instr.").append("\n");
+                }
+            });
+        });
+        explanation.replace(explanation.length() - 1, explanation.length(), "");
+        return explanation.toString();
+    }
+}

--- a/dspot/src/test/java/eu/stamp_project/MainTest.java
+++ b/dspot/src/test/java/eu/stamp_project/MainTest.java
@@ -218,6 +218,20 @@ public class MainTest {
     }
 
     @Test
+    public void testDevFriendlyAmplification() throws Exception {
+        Main.main(new String[]{
+                "--verbose",
+                "--absolute-path-to-project-root", new File("src/test/resources/test-projects/").getAbsolutePath() + "/",
+                "--amplifiers", "FastLiteralAmplifier",
+                "--test-criterion", "ExtendedCoverageSelector",
+                "--test", "example.TestSuiteExample2",
+                "--dev-friendly",
+        });
+        assertTrue(new File("target/dspot/output/example/TestSuiteExample2.java").exists());
+    }
+
+
+    @Test
     public void testExample() throws Exception {
 
         /*

--- a/dspot/src/test/java/eu/stamp_project/dspot/AbstractTestOnSample.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/AbstractTestOnSample.java
@@ -47,7 +47,6 @@ public class AbstractTestOnSample {
         DSpotCache.init(10000);
         RandomHelper.setSeedRandom(72L);
         this.testRunner = new TestRunner(getPathToProjectRoot(), "", false);
-
     }
 
     public String getPathToProjectRoot() {

--- a/dspot/src/test/java/eu/stamp_project/dspot/ProjectJSONTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/ProjectJSONTest.java
@@ -8,6 +8,7 @@ import eu.stamp_project.dspot.amplifier.amplifiers.value.ValueCreator;
 import eu.stamp_project.dspot.assertiongenerator.AssertionGenerator;
 import eu.stamp_project.dspot.assertiongenerator.assertiongenerator.AssertionGeneratorUtils;
 import eu.stamp_project.dspot.amplifier.InputAmplDistributor;
+import eu.stamp_project.dspot.common.configuration.options.CommentEnum;
 import eu.stamp_project.dspot.selector.JacocoCoverageSelector;
 import eu.stamp_project.dspot.selector.TestSelector;
 import eu.stamp_project.dspot.common.test_framework.TestFramework;
@@ -71,7 +72,7 @@ public class ProjectJSONTest extends AbstractTestOnSample {
         this.builder = AutomaticBuilderEnum.Maven.getAutomaticBuilder(configuration);
         this.initializeDSpot = new InitializeDSpot();
         String dependencies = initializeDSpot.completeDependencies(configuration, this.builder);
-        DSpotUtils.init(false, outputDirectory,
+        DSpotUtils.init(CommentEnum.None, outputDirectory,
                 this.configuration.getFullClassPathWithExtraDependencies(),
                 this.getPathToProjectRoot()
         );

--- a/dspot/src/test/java/eu/stamp_project/dspot/RecoveryDSpotTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/RecoveryDSpotTest.java
@@ -144,14 +144,14 @@ public class RecoveryDSpotTest extends AbstractTestOnSample {
         dspotState.setAssertionGenerator(new AssertionGenerator(0.1f, compiler, testCompiler));
         DSpot dspot = new DSpot(dspotState);
         dspot.fullAmplification(testClassToBeAmplified, testListToBeAmplified, Collections.emptyList(), 1);
-        assertEquals(1, DSpotState.GLOBAL_REPORT.getErrors().size());
+        assertEquals(2, DSpotState.GLOBAL_REPORT.getErrors().size());
         assertSame(ErrorEnum.ERROR_PRE_SELECTION, DSpotState.GLOBAL_REPORT.getErrors().get(0).type);
         DSpotState.GLOBAL_REPORT.reset();
 
         selector.setThrowsToAmplify(false);
         selector.setThrowsToKeep(true);
         dspot.fullAmplification(testClassToBeAmplified, testListToBeAmplified, Collections.emptyList(), 1);
-        assertEquals(1, DSpotState.GLOBAL_REPORT.getErrors().size());
+        assertEquals(2, DSpotState.GLOBAL_REPORT.getErrors().size());
         assertSame(ErrorEnum.ERROR_SELECTION, DSpotState.GLOBAL_REPORT.getErrors().get(0).type);
         DSpotState.GLOBAL_REPORT.reset();
 

--- a/dspot/src/test/java/eu/stamp_project/dspot/amplifier/TestMethodCallAdder.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/amplifier/TestMethodCallAdder.java
@@ -2,6 +2,10 @@ package eu.stamp_project.dspot.amplifier;
 
 import eu.stamp_project.dspot.AbstractTestOnSample;
 import eu.stamp_project.dspot.amplifier.amplifiers.MethodDuplicationAmplifier;
+import eu.stamp_project.dspot.common.configuration.UserInput;
+import eu.stamp_project.dspot.common.configuration.options.CommentEnum;
+import eu.stamp_project.dspot.common.miscellaneous.DSpotUtils;
+import org.junit.Before;
 import org.junit.Test;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtStatement;
@@ -9,6 +13,7 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.visitor.filter.TypeFilter;
 
+import java.io.File;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -21,6 +26,19 @@ import static org.junit.Assert.assertEquals;
  * on 12/7/16
  */
 public class TestMethodCallAdder extends AbstractTestOnSample {
+
+    @Before
+    @Override
+    public void setUp() {
+        UserInput configuration = new UserInput();
+        configuration.setAbsolutePathToProjectRoot(new File("src/test/resources/sample/").getAbsolutePath());
+
+        DSpotUtils.init(CommentEnum.Amplifier, "target/dspot/",
+                configuration.getFullClassPathWithExtraDependencies(),
+                "src/test/resources/sample/"
+        );
+        super.setUp();
+    }
 
     @Test
     public void testMethodCallAddOnInvocationWithCast() {

--- a/dspot/src/test/java/eu/stamp_project/dspot/common/compilation/TestCompilerTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/common/compilation/TestCompilerTest.java
@@ -3,6 +3,7 @@ package eu.stamp_project.dspot.common.compilation;
 import eu.stamp_project.dspot.common.automaticbuilder.AutomaticBuilder;
 import eu.stamp_project.dspot.AbstractTestOnSample;
 import eu.stamp_project.dspot.common.configuration.UserInput;
+import eu.stamp_project.dspot.common.configuration.options.CommentEnum;
 import eu.stamp_project.dspot.common.miscellaneous.DSpotUtils;
 import eu.stamp_project.dspot.common.configuration.InitializeDSpot;
 import eu.stamp_project.dspot.common.configuration.options.AutomaticBuilderEnum;
@@ -35,7 +36,7 @@ public class TestCompilerTest extends AbstractTestOnSample {
         final ArrayList<CtMethod<?>> methods = new ArrayList<>();
         methods.add(findMethod(testClass, "testAssertionError"));
         methods.add(findMethod(testClass, "testFailingWithException"));
-        DSpotUtils.init(false, "target/dspot/",
+        DSpotUtils.init(CommentEnum.None, "target/dspot/",
                 configuration.getFullClassPathWithExtraDependencies(), getPathToProjectRoot()
         );
         TestCompiler testCompiler = new TestCompiler(

--- a/dspot/src/test/java/eu/stamp_project/dspot/common/configuration/options/CommentTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/common/configuration/options/CommentTest.java
@@ -1,0 +1,164 @@
+package eu.stamp_project.dspot.common.configuration.options;
+
+import eu.stamp_project.Main;
+import eu.stamp_project.dspot.common.miscellaneous.AmplificationHelper;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertTrue;
+
+public class CommentTest {
+
+    private static final String TEST_CASE = "example.TestSuiteExample2";
+    private static final String PATH_OUTPUT_TEST_CLASS = "target/dspot/output/example/TestSuiteExample2.java";
+
+    @Before
+    public void setUp() {
+        try {
+            FileUtils.deleteDirectory(new File("target/trash"));
+            FileUtils.deleteDirectory(new File("src/test/resources/test-projects/target"));
+        } catch (Exception ignored) {
+
+        }
+    }
+
+    @After
+    public void tearDown() {
+        try {
+            FileUtils.deleteDirectory(new File("target/trash"));
+            FileUtils.deleteDirectory(new File("src/test/resources/test-projects/target"));
+        } catch (Exception ignored) {
+
+        }
+    }
+
+    private void assertFileStartsWith(String expectedStart) throws Exception{
+        final File amplifiedTestClass = new File(CommentTest.PATH_OUTPUT_TEST_CLASS);
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(amplifiedTestClass))) {
+            String content = reader.lines().collect(Collectors.joining(AmplificationHelper.LINE_SEPARATOR));
+            assertTrue(content.startsWith(expectedStart));
+        }
+    }
+
+    private void assertFileContains(String expected) throws Exception{
+        final File amplifiedTestClass = new File(CommentTest.PATH_OUTPUT_TEST_CLASS);
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(amplifiedTestClass))) {
+            String content = reader.lines().collect(Collectors.joining(AmplificationHelper.LINE_SEPARATOR));
+            assertTrue(content.contains(expected));
+        }
+    }
+
+    @Test
+    public void testJacocoCoverageComments() throws Exception {
+        Main.main(new String[]{
+                "--verbose",
+                "--absolute-path-to-project-root", new File("src/test/resources/test-projects/").getAbsolutePath() + "/",
+                "--amplifiers", "FastLiteralAmplifier",
+                "--test-criterion", "JacocoCoverageSelector",
+                "--test", TEST_CASE,
+                "--clean",
+                "--with-comment=All",
+        });
+        String expectedAmplifiedTestClassBegin = "package example;" + AmplificationHelper.LINE_SEPARATOR +
+                "import org.junit.Assert;" + AmplificationHelper.LINE_SEPARATOR +
+                "import org.junit.Test;" + AmplificationHelper.LINE_SEPARATOR +
+                "public class TestSuiteExample2 {" + AmplificationHelper.LINE_SEPARATOR +
+                "    private static int integer = TestResources.integer;" + AmplificationHelper.LINE_SEPARATOR +
+                "" + AmplificationHelper.LINE_SEPARATOR +
+                "    // JacocoCoverageSelector: Improves instruction coverage to 15/34" + AmplificationHelper.LINE_SEPARATOR +
+                "    @Test(timeout = 10000)" + AmplificationHelper.LINE_SEPARATOR +
+                "    public void test3_literalMutationString50_failAssert0() throws Exception {" + AmplificationHelper.LINE_SEPARATOR +
+                "        // AssertionGenerator generate try/catch block with fail statement" + AmplificationHelper.LINE_SEPARATOR +
+                "        try {";
+
+        assertTrue(new File(PATH_OUTPUT_TEST_CLASS).exists());
+        assertFileStartsWith(expectedAmplifiedTestClassBegin);
+    }
+
+    @Test
+    public void testDevFriendlyAllComments() throws Exception {
+        Main.main(new String[]{
+                "--verbose",
+                "--absolute-path-to-project-root", new File("src/test/resources/test-projects/").getAbsolutePath() + "/",
+                "--amplifiers", "FastLiteralAmplifier",
+                "--test-criterion", "ExtendedCoverageSelector",
+                "--test", TEST_CASE,
+                "--clean",
+                "--with-comment=All",
+                "--dev-friendly",
+        });
+        String classComment =
+                "/* Coverage improved at" + AmplificationHelper.LINE_SEPARATOR +
+                        "    example.Example:" + AmplificationHelper.LINE_SEPARATOR +
+                        "    charAt" + AmplificationHelper.LINE_SEPARATOR  +
+                        "    L. 7 +7 instr." + AmplificationHelper.LINE_SEPARATOR +
+                        "     */";
+        String amplifierComment =
+                "        // AssertionGenerator: add assertion";
+        assertTrue(new File(PATH_OUTPUT_TEST_CLASS).exists());
+        assertFileContains(classComment);
+        assertFileContains(amplifierComment);
+    }
+
+    @Test
+    public void testAmplifierComments() throws Exception {
+        Main.main(new String[]{
+                "--verbose",
+                "--absolute-path-to-project-root", new File("src/test/resources/test-projects/").getAbsolutePath() + "/",
+                "--amplifiers", "FastLiteralAmplifier",
+                "--test-criterion", "ExtendedCoverageSelector",
+                "--test", TEST_CASE,
+                "--clean",
+                "--with-comment=Amplifier",
+                "--dev-friendly",
+        });
+        String commentAndExpression =
+                "        // FastLiteralAmplifier: change number from '1' to '0.0'" + AmplificationHelper.LINE_SEPARATOR +
+                "        // AssertionGenerator: create local variable with return value of invocation" + AmplificationHelper.LINE_SEPARATOR +
+                "        char o_test3_literalMutationNumber41__4 = ex.charAt(s, s.length() - 0);";
+        assertTrue(new File(PATH_OUTPUT_TEST_CLASS).exists());
+        assertFileContains(commentAndExpression);
+    }
+
+    @Test
+    public void testNoComments() throws Exception {
+        Main.main(new String[]{
+                "--verbose",
+                "--absolute-path-to-project-root", new File("src/test/resources/test-projects/").getAbsolutePath() + "/",
+                "--amplifiers", "FastLiteralAmplifier",
+                "--test-criterion", "JacocoCoverageSelector",
+                "--test", TEST_CASE,
+                "--clean",
+                "--with-comment=None",
+                //"--dev-friendly",
+        });
+        String expectedAmplifiedTestClassBegin = "package example;" + AmplificationHelper.LINE_SEPARATOR +
+                "import org.junit.Assert;" + AmplificationHelper.LINE_SEPARATOR +
+                "import org.junit.Test;" + AmplificationHelper.LINE_SEPARATOR +
+                "public class TestSuiteExample2 {" + AmplificationHelper.LINE_SEPARATOR +
+                "    private static int integer = TestResources.integer;" + AmplificationHelper.LINE_SEPARATOR +
+                "" + AmplificationHelper.LINE_SEPARATOR +
+                "    @Test(timeout = 10000)" + AmplificationHelper.LINE_SEPARATOR +
+                "    public void test3_literalMutationString50_failAssert0() throws Exception {" + AmplificationHelper.LINE_SEPARATOR +
+                "        try {" + AmplificationHelper.LINE_SEPARATOR +
+                "            Example ex = new Example();" + AmplificationHelper.LINE_SEPARATOR +
+                "            String s = \"\";" + AmplificationHelper.LINE_SEPARATOR +
+                "            ex.charAt(s, s.length() - 1);" + AmplificationHelper.LINE_SEPARATOR +
+                "            Assert.fail(\"test3_literalMutationString50 should have thrown StringIndexOutOfBoundsException\");" + AmplificationHelper.LINE_SEPARATOR +
+                "        } catch (StringIndexOutOfBoundsException expected) {" + AmplificationHelper.LINE_SEPARATOR +
+                "            Assert.assertEquals(\"String index out of range: 0\", expected.getMessage());" + AmplificationHelper.LINE_SEPARATOR +
+                "        }" + AmplificationHelper.LINE_SEPARATOR +
+                "    }";
+        assertTrue(new File(PATH_OUTPUT_TEST_CLASS).exists());
+        assertFileStartsWith(expectedAmplifiedTestClassBegin);
+    }
+}

--- a/dspot/src/test/java/eu/stamp_project/dspot/common/miscellaneous/DSpotUtilsTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/common/miscellaneous/DSpotUtilsTest.java
@@ -7,6 +7,7 @@ import eu.stamp_project.dspot.common.compilation.TestCompiler;
 import eu.stamp_project.dspot.common.configuration.InitializeDSpot;
 import eu.stamp_project.dspot.common.configuration.UserInput;
 import eu.stamp_project.dspot.common.configuration.options.AutomaticBuilderEnum;
+import eu.stamp_project.dspot.common.configuration.options.CommentEnum;
 import eu.stamp_project.dspot.common.miscellaneous.AmplificationHelper;
 import eu.stamp_project.dspot.common.miscellaneous.DSpotUtils;
 import eu.stamp_project.dspot.common.collector.NullCollector;
@@ -67,7 +68,7 @@ public class DSpotUtilsTest extends AbstractTestOnSample {
         this.builder = AutomaticBuilderEnum.Maven.getAutomaticBuilder(configuration);
         this.initializeDSpot = new InitializeDSpot();
         String dependencies = initializeDSpot.completeDependencies(configuration, this.builder);
-        DSpotUtils.init(false,
+        DSpotUtils.init(CommentEnum.None,
                 outputDirectory.getAbsolutePath(),
                 this.configuration.getFullClassPathWithExtraDependencies(),
                 this.getPathToProjectRoot()

--- a/dspot/src/test/java/eu/stamp_project/dspot/common/test_framework/TestFrameworkTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/common/test_framework/TestFrameworkTest.java
@@ -1,21 +1,24 @@
 package eu.stamp_project.dspot.common.test_framework;
 
 import eu.stamp_project.dspot.AbstractTestOnSample;
+import eu.stamp_project.dspot.common.configuration.UserInput;
+import eu.stamp_project.dspot.common.configuration.options.CommentEnum;
+import eu.stamp_project.dspot.common.miscellaneous.AmplificationHelper;
+import eu.stamp_project.dspot.common.miscellaneous.DSpotUtils;
 import eu.stamp_project.dspot.common.test_framework.assertions.AssertEnum;
 import eu.stamp_project.testrunner.runner.Failure;
-import eu.stamp_project.dspot.common.miscellaneous.AmplificationHelper;
+import org.junit.Before;
 import org.junit.Test;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * created by Benjamin DANGLOT
@@ -23,6 +26,16 @@ import static org.junit.Assert.assertTrue;
  * on 09/11/18
  */
 public class TestFrameworkTest extends AbstractTestOnSample {
+
+    @Before
+    @Override
+    public void setUp() {
+        UserInput configuration = new UserInput();
+        configuration.setAbsolutePathToProjectRoot(new File("src/test/resources/sample/").getAbsolutePath());
+        DSpotUtils.init(CommentEnum.Amplifier, "target/dspot/", configuration
+                .getFullClassPathWithExtraDependencies(), "src/test/resources/sample/");
+        super.setUp();
+    }
 
     private CtMethod findAndRegister(String ctClass, String methodName) {
         final CtMethod testExpectingAnException = findMethod(ctClass, methodName);

--- a/dspot/src/test/java/eu/stamp_project/dspot/selector/AbstractSelectorRemoveOverlapTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/selector/AbstractSelectorRemoveOverlapTest.java
@@ -7,7 +7,10 @@ import eu.stamp_project.dspot.amplifier.amplifiers.StringLiteralAmplifier;
 import eu.stamp_project.dspot.amplifier.amplifiers.value.ValueCreator;
 import eu.stamp_project.dspot.assertiongenerator.AssertionGenerator;
 import eu.stamp_project.dspot.assertiongenerator.assertiongenerator.AssertionGeneratorUtils;
+import eu.stamp_project.dspot.common.collector.CollectorFactory;
+import eu.stamp_project.dspot.common.collector.NullCollector;
 import eu.stamp_project.dspot.common.configuration.UserInput;
+import eu.stamp_project.dspot.common.configuration.options.CommentEnum;
 import eu.stamp_project.dspot.common.test_framework.TestFramework;
 import eu.stamp_project.dspot.common.configuration.DSpotCache;
 import eu.stamp_project.dspot.common.miscellaneous.DSpotUtils;
@@ -80,7 +83,7 @@ public abstract class AbstractSelectorRemoveOverlapTest {
         this.builder = AutomaticBuilderEnum.Maven.getAutomaticBuilder(configuration);
         this.initializeDSpot = new InitializeDSpot();
         String dependencies = initializeDSpot.completeDependencies(configuration, this.builder);
-        DSpotUtils.init(false, outputDirectory,
+        DSpotUtils.init(CommentEnum.None, outputDirectory,
                 this.configuration.getFullClassPathWithExtraDependencies(),
                 this.getPathToAbsoluteProjectRoot()
         );
@@ -120,7 +123,7 @@ public abstract class AbstractSelectorRemoveOverlapTest {
         dspotState.setTestSelector(this.testSelectorUnderTest);
         dspotState.setInputAmplDistributor(InputAmplDistributorEnum.RandomInputAmplDistributor.getInputAmplDistributor(
                 200, Collections.singletonList(new StringLiteralAmplifier())));
-        dspotState.setOutput(new Output(getPathToAbsoluteProjectRoot(), configuration.getOutputDirectory(), null));
+        dspotState.setOutput(new Output(getPathToAbsoluteProjectRoot(), configuration.getOutputDirectory(), new NullCollector()));
         dspotState.setNbIteration(1);
         dspotState.setAutomaticBuilder(builder);
         dspotState.setTestCompiler(testCompiler);

--- a/dspot/src/test/java/eu/stamp_project/dspot/selector/AbstractSelectorTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/selector/AbstractSelectorTest.java
@@ -5,6 +5,7 @@ import eu.stamp_project.dspot.common.automaticbuilder.maven.DSpotPOMCreator;
 import eu.stamp_project.dspot.amplifier.amplifiers.value.ValueCreator;
 import eu.stamp_project.dspot.assertiongenerator.assertiongenerator.AssertionGeneratorUtils;
 import eu.stamp_project.dspot.common.configuration.UserInput;
+import eu.stamp_project.dspot.common.configuration.options.CommentEnum;
 import eu.stamp_project.dspot.common.test_framework.TestFramework;
 import eu.stamp_project.dspot.common.configuration.DSpotCache;
 import eu.stamp_project.dspot.common.miscellaneous.DSpotUtils;
@@ -82,7 +83,7 @@ public abstract class AbstractSelectorTest {
         this.builder = AutomaticBuilderEnum.Maven.getAutomaticBuilder(configuration);
         this.initializeDSpot = new InitializeDSpot();
         String dependencies = initializeDSpot.completeDependencies(configuration, this.builder);
-        DSpotUtils.init(false, outputDirectory,
+        DSpotUtils.init(CommentEnum.None, outputDirectory,
                 this.configuration.getFullClassPathWithExtraDependencies(),
                 this.getPathToAbsoluteProjectRoot()
         );

--- a/dspot/src/test/java/eu/stamp_project/dspot/selector/ExtendedCoverageSelectorTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/selector/ExtendedCoverageSelectorTest.java
@@ -1,0 +1,29 @@
+package eu.stamp_project.dspot.selector;
+
+import eu.stamp_project.dspot.common.configuration.DSpotState;
+import eu.stamp_project.testrunner.EntryPoint;
+import eu.stamp_project.testrunner.runner.ParserOptions;
+
+import java.text.DecimalFormat;
+
+public class ExtendedCoverageSelectorTest extends AbstractSelectorRemoveOverlapTest {
+
+    @Override
+    protected TestSelector getTestSelector() {
+        return new ExtendedCoverageSelector(
+                this.builder,
+                this.configuration
+        );
+    }
+
+    @Override
+    protected String getContentReportFile() {
+        return "Amplification results with 2 new tests.";
+    }
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        EntryPoint.coverageDetail = ParserOptions.CoverageTransformerDetail.METHOD_DETAIL;
+    }
+}

--- a/dspot/src/test/java/eu/stamp_project/dspot/selector/extendedcoverageselector/ExtendedCoverageTest.java
+++ b/dspot/src/test/java/eu/stamp_project/dspot/selector/extendedcoverageselector/ExtendedCoverageTest.java
@@ -1,0 +1,72 @@
+package eu.stamp_project.dspot.selector.extendedcoverageselector;
+
+import eu.stamp_project.testrunner.listener.Coverage;
+import eu.stamp_project.testrunner.listener.impl.CoverageImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ExtendedCoverageTest {
+
+    String EXECUTION_PATH_1 = "package.package.class:method1+()V+1,0,3,0|method2+(LCallback;)V+0,4" +
+            "-package.package.class2:method1+()V+4,3,0";
+    String EXECUTION_PATH_2 = "package.package.class:method1+()V+1,0,3,5|method2+(LCallback;)V+0,1" +
+            "-package.package.class2:method1+()V+4,3,0";
+    String EXECUTION_PATH_3 = "package.package.class:method1+()V+1,0,3,5|method2+(LCallback;)V+0,4" +
+            "-package.package.class2:method1+()V+4,3,0";
+
+    private ExtendedCoverage genExtendedCoverageWithPath(String executionPath) {
+        Coverage coverage = new CoverageImpl(8, 10);
+        coverage.setExecutionPath(executionPath);
+
+        return new ExtendedCoverage(coverage);
+    }
+
+    @Test
+    public void constructExtendedCoverageFromCoverage() {
+        ExtendedCoverage extendedCoverage = genExtendedCoverageWithPath(EXECUTION_PATH_1);
+
+        ProjectCoverageMap instructionsCoveredPerClass = new ProjectCoverageMap();
+        ClassCoverageMap instructionsCoveredPerMethod = new ClassCoverageMap();
+        instructionsCoveredPerMethod.addMethodCoverage("method1", new MethodCoverage(Arrays.asList(1, 0, 3, 0), "()V"));
+        instructionsCoveredPerMethod.addMethodCoverage("method2", new MethodCoverage(Arrays.asList(0, 4), "(LCallback;)V"));
+        instructionsCoveredPerClass.addClassCoverage("package.package.class", instructionsCoveredPerMethod);
+        ClassCoverageMap instructionsCoveredPerMethod2 = new ClassCoverageMap();
+        instructionsCoveredPerMethod2.addMethodCoverage("method1", new MethodCoverage(Arrays.asList(4, 3, 0),
+                "()V"));
+        instructionsCoveredPerClass.addClassCoverage("package.package.class2", instructionsCoveredPerMethod2);
+
+        Assert.assertEquals(extendedCoverage.getInstructionsProjectCoverageMap(), instructionsCoveredPerClass);
+    }
+
+    @Test
+    public void testAccumulate() {
+        ExtendedCoverage extendedCoverage = genExtendedCoverageWithPath(EXECUTION_PATH_1);
+        ExtendedCoverage extendedCoverage2 = genExtendedCoverageWithPath(EXECUTION_PATH_2);
+
+        extendedCoverage.accumulate(extendedCoverage2);
+
+        Assert.assertEquals(extendedCoverage, genExtendedCoverageWithPath(EXECUTION_PATH_3));
+    }
+
+    @Test
+    public void testBetterThan() {
+        ExtendedCoverage extendedCoverage = genExtendedCoverageWithPath(EXECUTION_PATH_1);
+        ExtendedCoverage extendedCoverage2 = genExtendedCoverageWithPath(EXECUTION_PATH_2);
+
+        Assert.assertTrue(extendedCoverage.isBetterThan(extendedCoverage2));
+        Assert.assertTrue(extendedCoverage2.isBetterThan(extendedCoverage));
+    }
+
+    @Test
+    public void testBetterThanNotReflexive() {
+        ExtendedCoverage extendedCoverage = genExtendedCoverageWithPath(EXECUTION_PATH_1);
+
+        Assert.assertFalse(extendedCoverage.isBetterThan(extendedCoverage));
+    }
+
+}

--- a/dspot/src/test/resources/mockito/pom.xml
+++ b/dspot/src/test/resources/mockito/pom.xml
@@ -22,4 +22,8 @@
             <version>2.10.0</version>
         </dependency>
     </dependencies>
+    <properties>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+    </properties>
 </project>


### PR DESCRIPTION
This pull request contains the adaptations I made to DSpot to let it generated smaller and better explained (though maybe weaker) test cases for the [Test Cube IntelliJ Plugin](https://github.com/TestShiftProject/test-cube). 

As it contains many changes, I want to summarize and explain the main points:

## New "main" class `DevFriendlyAmplification`

This class is analogous to the class `DSpot` , orchestrates the developer friendly test amplification and is called from `DSpot` when the option `--dev-friendly` is passed.

In a nutshell, the developer-friendly amplification:

- removes assertions at the end of a test case completely (also the statements in the assertions)
- adds only one new assertion per test case, so returns multiple test cases with the same input-amplification but each different assertions
- uses the `ExtendedCoverageSelector` to keep test cases that cover more instructions on any line

## New `ExtendedCoverageSelector`  + connected classes

Selects test cases that cover more instructions (than the original test suite) on any line of code and provides a detailed report in which lines how many more instructions are covered.

The selector uses the new, more detailed information from test-runner 2.3.0

## Fine-grained options for generated comments

I extended the comment generation to each amplifier.

In addition, the `JacocoCoverageSelector` and the `ExtendedCoverageSelector` can add JavaDoc comments about the improved coverage above each test case.

The new `CommentEnum` allows to configure which comments should be included (None, only Amplifiers, only Coverage, all comments).

## Tests of new functionality

This PR includes the following tests:

- a new MainTest with the `--dev-friendly` option
- tests of the new comments, especially for the two coverage selectors. Adaptations to some existing tests to correctly set comment option.
- tests of the `ExtendedCoverageSelector` , especially calculation of the difference in coverage per line

